### PR TITLE
Support Tinyint and Smallint predicate

### DIFF
--- a/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoFilterConverter.java
+++ b/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoFilterConverter.java
@@ -40,6 +40,8 @@ import io.trino.spi.type.IntegerType;
 import io.trino.spi.type.LongTimestampWithTimeZone;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.RealType;
+import io.trino.spi.type.SmallintType;
+import io.trino.spi.type.TinyintType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
@@ -203,6 +205,14 @@ public class TrinoFilterConverter {
 
         if (type instanceof BooleanType) {
             return trinoNativeValue;
+        }
+
+        if (type instanceof TinyintType) {
+            return ((Long) trinoNativeValue).byteValue();
+        }
+
+        if (type instanceof SmallintType) {
+            return ((Long) trinoNativeValue).shortValue();
         }
 
         if (type instanceof IntegerType) {

--- a/paimon-trino-common/src/test/java/org/apache/paimon/trino/TestTrinoFilterConverter.java
+++ b/paimon-trino-common/src/test/java/org/apache/paimon/trino/TestTrinoFilterConverter.java
@@ -33,8 +33,10 @@ import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.predicate.ValueSet;
 import io.trino.spi.type.CharType;
+import io.trino.spi.type.SmallintType;
 import io.trino.spi.type.TimeZoneKey;
 import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TinyintType;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -210,6 +212,45 @@ public class TestTrinoFilterConverter {
                                         createTimestampWithTimeZoneType(3), 1695645403000L)));
         expectedEqq = builder.equal(0, 1695645403000L);
         actualEqq = converter.convert(eq).get();
+        assertThat(actualEqq).isEqualTo(expectedEqq);
+    }
+
+    @Test
+    public void testTinyint() {
+        RowType rowType =
+                new RowType(
+                        Collections.singletonList(
+                                new DataField(
+                                        0, "tiny", new org.apache.paimon.types.TinyIntType())));
+        TrinoFilterConverter converter = new TrinoFilterConverter(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        TrinoColumnHandle idColumn =
+                TrinoColumnHandle.of("tiny", new org.apache.paimon.types.TinyIntType());
+        TupleDomain<TrinoColumnHandle> eq =
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(idColumn, Domain.singleValue(TinyintType.TINYINT, 127L)));
+        Predicate expectedEqq = builder.equal(0, Byte.MAX_VALUE);
+        Predicate actualEqq = converter.convert(eq).get();
+        assertThat(actualEqq).isEqualTo(expectedEqq);
+    }
+
+    @Test
+    public void testSmallint() {
+        RowType rowType =
+                new RowType(
+                        Collections.singletonList(
+                                new DataField(
+                                        0, "small", new org.apache.paimon.types.SmallIntType())));
+        TrinoFilterConverter converter = new TrinoFilterConverter(rowType);
+        PredicateBuilder builder = new PredicateBuilder(rowType);
+        TrinoColumnHandle idColumn =
+                TrinoColumnHandle.of("small", new org.apache.paimon.types.SmallIntType());
+        TupleDomain<TrinoColumnHandle> eq =
+                TupleDomain.withColumnDomains(
+                        ImmutableMap.of(
+                                idColumn, Domain.singleValue(SmallintType.SMALLINT, 32767L)));
+        Predicate expectedEqq = builder.equal(0, Short.MAX_VALUE);
+        Predicate actualEqq = converter.convert(eq).get();
         assertThat(actualEqq).isEqualTo(expectedEqq);
     }
 }


### PR DESCRIPTION
Currently, the generation of predicates ignores data of the Tinyint and Smallint types.