### PR TITLE
Implement `listDirectories` in `TrinoFileIO`, reduce the chance of calling `trinoFileSystem.listFiles` which is recursive

### DIFF
--- a/paimon-trino-common/src/main/java/org/apache/paimon/trino/fileio/TrinoFileIO.java
+++ b/paimon-trino-common/src/main/java/org/apache/paimon/trino/fileio/TrinoFileIO.java
@@ -111,6 +111,13 @@ public class TrinoFileIO implements FileIO {
     }
 
     @Override
+    public FileStatus[] listDirectories(Path path) throws IOException {
+        return trinoFileSystem.listDirectories(Location.of(path.toString())).stream()
+                .map(l -> new TrinoDirectoryFileStatus(new Path(l.toString())))
+                .toArray(FileStatus[]::new);
+    }
+
+    @Override
     public boolean exists(Path path) throws IOException {
         return trinoFileSystem.directoryExists(Location.of(path.toString())).orElse(false)
                 || existFile(Location.of(path.toString()));


### PR DESCRIPTION
Close: https://github.com/apache/paimon-trino/issues/61