### PR TITLE
prefer central repo for releases; limit apache-snapshots to snapshots

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -322,14 +322,27 @@ under the License.
             <id>apache-build</id>
             <repositories>
                 <repository>
+                    <id>central</id>
+                    <url>https://repo.maven.apache.org/maven2</url>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+                <repository>
                     <id>apache-releases</id>
                     <name>apache releases</name>
                     <url>https://repository.apache.org/content/repositories/releases/</url>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
                 </repository>
                 <repository>
                     <id>apache-snapshots</id>
                     <name>apache snapshots</name>
                     <url>https://repository.apache.org/content/repositories/snapshots/</url>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
                 </repository>
             </repositories>
         </profile>


### PR DESCRIPTION
### Purpose

- Avoid trying to download release artifacts from Apache snapshot repo.
- Add `central` repo to ensure it's preferred to `repository.apache.org` when downloading release artifacts.

see also https://github.com/apache/paimon/pull/4707

### Tests

```
$ mvn -DskipTests -Papache-build clean package
...
[INFO] BUILD SUCCESS
```