### PR TITLE
Support incremental reading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@ under the License.
     </scm>
 
     <properties>
-        <paimon.version>1.0-SNAPSHOT</paimon.version>
+        <paimon.version>1.0.0</paimon.version>
         <target.java.version>21</target.java.version>
         <jdk.test.version>21</jdk.test.version>
         <trino.version>440</trino.version>

--- a/src/main/java/org/apache/paimon/trino/TrinoConnectorFactory.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoConnectorFactory.java
@@ -22,6 +22,7 @@ import org.apache.paimon.utils.StringUtils;
 
 import com.google.inject.Binder;
 import com.google.inject.Injector;
+import com.google.inject.Key;
 import com.google.inject.Module;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
@@ -40,6 +41,8 @@ import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
+import io.trino.spi.function.FunctionProvider;
+import io.trino.spi.function.table.ConnectorTableFunction;
 import io.trino.spi.type.TypeManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,6 +57,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 /** Trino {@link ConnectorFactory}. */
 public class TrinoConnectorFactory implements ConnectorFactory {
@@ -137,6 +141,9 @@ public class TrinoConnectorFactory implements ConnectorFactory {
             TrinoSessionProperties trinoSessionProperties =
                     injector.getInstance(TrinoSessionProperties.class);
             TrinoTableOptions trinoTableOptions = injector.getInstance(TrinoTableOptions.class);
+            Set<ConnectorTableFunction> connectorTableFunctions =
+                    injector.getInstance(new Key<>() {});
+            FunctionProvider functionProvider = injector.getInstance(FunctionProvider.class);
 
             return new TrinoConnector(
                     new ClassLoaderSafeConnectorMetadata(trinoMetadata, classLoader),
@@ -147,7 +154,9 @@ public class TrinoConnectorFactory implements ConnectorFactory {
                             trinoPageSinkProvider, classLoader),
                     trinoNodePartitioningProvider,
                     trinoTableOptions,
-                    trinoSessionProperties);
+                    trinoSessionProperties,
+                    connectorTableFunctions,
+                    functionProvider);
         }
     }
 

--- a/src/main/java/org/apache/paimon/trino/TrinoModule.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoModule.java
@@ -19,13 +19,20 @@
 package org.apache.paimon.trino;
 
 import org.apache.paimon.options.Options;
+import org.apache.paimon.trino.functions.TrinoFunctionProvider;
+import org.apache.paimon.trino.functions.tablechanges.TableChangesFunctionProcessorProvider;
+import org.apache.paimon.trino.functions.tablechanges.TableChangesFunctionProvider;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
+import com.google.inject.Scopes;
+import io.trino.spi.function.FunctionProvider;
+import io.trino.spi.function.table.ConnectorTableFunction;
 
 import java.util.Map;
 
 import static com.google.inject.Scopes.SINGLETON;
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
 
 /** Module for binding instance. */
 public class TrinoModule implements Module {
@@ -45,5 +52,11 @@ public class TrinoModule implements Module {
         binder.bind(TrinoNodePartitioningProvider.class).in(SINGLETON);
         binder.bind(TrinoSessionProperties.class).in(SINGLETON);
         binder.bind(TrinoTableOptions.class).in(SINGLETON);
+        newSetBinder(binder, ConnectorTableFunction.class)
+                .addBinding()
+                .toProvider(TableChangesFunctionProvider.class)
+                .in(Scopes.SINGLETON);
+        binder.bind(FunctionProvider.class).to(TrinoFunctionProvider.class).in(Scopes.SINGLETON);
+        binder.bind(TableChangesFunctionProcessorProvider.class).in(SINGLETON);
     }
 }

--- a/src/main/java/org/apache/paimon/trino/TrinoSplitManager.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoSplitManager.java
@@ -66,8 +66,8 @@ public class TrinoSplitManager implements ConnectorSplitManager {
             ConnectorTransactionHandle transaction,
             ConnectorSession session,
             ConnectorTableFunctionHandle function) {
-        if (function instanceof TrinoTableHandle functionHandle) {
-            return getSplits(functionHandle, session);
+        if (function instanceof TrinoTableHandle) {
+            return getSplits((TrinoTableHandle) function, session);
         }
         throw new IllegalStateException("Unknown table function: " + function);
     }

--- a/src/main/java/org/apache/paimon/trino/TrinoTableHandle.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoTableHandle.java
@@ -34,6 +34,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.function.table.ConnectorTableFunctionHandle;
 import io.trino.spi.predicate.TupleDomain;
 
 import java.util.Collections;
@@ -47,7 +48,10 @@ import java.util.stream.Collectors;
 
 /** Trino {@link ConnectorTableHandle}. */
 public class TrinoTableHandle
-        implements ConnectorTableHandle, ConnectorInsertTableHandle, ConnectorOutputTableHandle {
+        implements ConnectorTableHandle,
+                ConnectorInsertTableHandle,
+                ConnectorOutputTableHandle,
+                ConnectorTableFunctionHandle {
 
     private final String schemaName;
     private final String tableName;
@@ -75,7 +79,7 @@ public class TrinoTableHandle
             @JsonProperty("tableName") String tableName,
             @JsonProperty("dynamicOptions") Map<String, String> dynamicOptions,
             @JsonProperty("filter") TupleDomain<TrinoColumnHandle> filter,
-            @JsonProperty("projection") Optional<List<ColumnHandle>> projectedColumns,
+            @JsonProperty("projectedColumns") Optional<List<ColumnHandle>> projectedColumns,
             @JsonProperty("limit") OptionalLong limit) {
         this.schemaName = schemaName;
         this.tableName = tableName;

--- a/src/main/java/org/apache/paimon/trino/TrinoTableOptionUtils.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoTableOptionUtils.java
@@ -124,7 +124,7 @@ public class TrinoTableOptionUtils {
         }
     }
 
-    private static String convertOptionKey(String key) {
+    public static String convertOptionKey(String key) {
         String regex = "[.\\-]";
         Pattern pattern = Pattern.compile(regex);
         Matcher matcher = pattern.matcher(key);

--- a/src/main/java/org/apache/paimon/trino/catalog/TrinoCatalog.java
+++ b/src/main/java/org/apache/paimon/trino/catalog/TrinoCatalog.java
@@ -23,10 +23,10 @@ import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogFactory;
 import org.apache.paimon.catalog.Database;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.catalog.PropertyChange;
 import org.apache.paimon.fs.FileIO;
-import org.apache.paimon.fs.Path;
-import org.apache.paimon.manifest.PartitionEntry;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.partition.Partition;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.security.SecurityContext;
@@ -110,6 +110,11 @@ public class TrinoCatalog implements Catalog {
     }
 
     @Override
+    public boolean caseSensitive() {
+        return current.caseSensitive();
+    }
+
+    @Override
     public FileIO fileIO() {
         if (!inited) {
             throw new RuntimeException("Not inited yet.");
@@ -140,13 +145,14 @@ public class TrinoCatalog implements Catalog {
     }
 
     @Override
-    public Table getTable(Identifier identifier) throws TableNotExistException {
-        return current.getTable(identifier);
+    public void alterDatabase(String s, List<PropertyChange> list, boolean b)
+            throws DatabaseNotExistException {
+        current.alterDatabase(s, list, b);
     }
 
     @Override
-    public Path getTableLocation(Identifier identifier) {
-        return current.getTableLocation(identifier);
+    public Table getTable(Identifier identifier) throws TableNotExistException {
+        return current.getTable(identifier);
     }
 
     @Override
@@ -190,8 +196,7 @@ public class TrinoCatalog implements Catalog {
     }
 
     @Override
-    public List<PartitionEntry> listPartitions(Identifier identifier)
-            throws TableNotExistException {
+    public List<Partition> listPartitions(Identifier identifier) throws TableNotExistException {
         return current.listPartitions(identifier);
     }
 
@@ -212,10 +217,5 @@ public class TrinoCatalog implements Catalog {
     public void alterTable(Identifier identifier, SchemaChange change, boolean ignoreIfNotExists)
             throws TableNotExistException, ColumnAlreadyExistException, ColumnNotExistException {
         current.alterTable(identifier, change, ignoreIfNotExists);
-    }
-
-    @Override
-    public boolean allowUpperCase() {
-        return current.allowUpperCase();
     }
 }

--- a/src/main/java/org/apache/paimon/trino/functions/TrinoFunctionProvider.java
+++ b/src/main/java/org/apache/paimon/trino/functions/TrinoFunctionProvider.java
@@ -27,6 +27,7 @@ import io.trino.spi.function.FunctionProvider;
 import io.trino.spi.function.table.ConnectorTableFunctionHandle;
 import io.trino.spi.function.table.TableFunctionProcessorProvider;
 
+/** TrinoFunctionProvider. */
 public class TrinoFunctionProvider implements FunctionProvider {
 
     private final TableChangesFunctionProcessorProvider tableChangesFunctionProcessorProvider;

--- a/src/main/java/org/apache/paimon/trino/functions/TrinoFunctionProvider.java
+++ b/src/main/java/org/apache/paimon/trino/functions/TrinoFunctionProvider.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.trino.functions;
+
+import org.apache.paimon.trino.TrinoTableHandle;
+import org.apache.paimon.trino.functions.tablechanges.TableChangesFunctionProcessorProvider;
+
+import com.google.inject.Inject;
+import io.trino.plugin.base.classloader.ClassLoaderSafeTableFunctionProcessorProvider;
+import io.trino.spi.function.FunctionProvider;
+import io.trino.spi.function.table.ConnectorTableFunctionHandle;
+import io.trino.spi.function.table.TableFunctionProcessorProvider;
+
+public class TrinoFunctionProvider implements FunctionProvider {
+
+    private final TableChangesFunctionProcessorProvider tableChangesFunctionProcessorProvider;
+
+    @Inject
+    public TrinoFunctionProvider(
+            TableChangesFunctionProcessorProvider tableChangesFunctionProcessorProvider) {
+        this.tableChangesFunctionProcessorProvider = tableChangesFunctionProcessorProvider;
+    }
+
+    @Override
+    public TableFunctionProcessorProvider getTableFunctionProcessorProvider(
+            ConnectorTableFunctionHandle functionHandle) {
+        if (functionHandle instanceof TrinoTableHandle) {
+            return new ClassLoaderSafeTableFunctionProcessorProvider(
+                    tableChangesFunctionProcessorProvider, getClass().getClassLoader());
+        }
+        return FunctionProvider.super.getTableFunctionProcessorProvider(functionHandle);
+    }
+}

--- a/src/main/java/org/apache/paimon/trino/functions/tablechanges/TableChangesFunction.java
+++ b/src/main/java/org/apache/paimon/trino/functions/tablechanges/TableChangesFunction.java
@@ -215,8 +215,8 @@ public class TableChangesFunction extends AbstractConnectorTableFunction {
 
     private static boolean argumentExists(Map<String, Argument> arguments, String key) {
         Argument argument = arguments.get(key);
-        if (argument instanceof ScalarArgument scalarArgument) {
-            return !scalarArgument.getNullableValue().isNull();
+        if (argument instanceof ScalarArgument) {
+            return !((ScalarArgument) argument).getNullableValue().isNull();
         }
         throw new IllegalArgumentException("Unsupported argument type: " + argument);
     }

--- a/src/main/java/org/apache/paimon/trino/functions/tablechanges/TableChangesFunction.java
+++ b/src/main/java/org/apache/paimon/trino/functions/tablechanges/TableChangesFunction.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.trino.functions.tablechanges;
+
+import org.apache.paimon.CoreOptions;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
+import org.apache.paimon.table.Table;
+import org.apache.paimon.trino.TrinoColumnHandle;
+import org.apache.paimon.trino.TrinoMetadata;
+import org.apache.paimon.trino.TrinoMetadataFactory;
+import org.apache.paimon.trino.TrinoTableHandle;
+import org.apache.paimon.trino.TrinoTableOptionUtils;
+import org.apache.paimon.trino.TrinoTypeUtils;
+import org.apache.paimon.trino.catalog.TrinoCatalog;
+
+import com.google.inject.Inject;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorAccessControl;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.function.table.AbstractConnectorTableFunction;
+import io.trino.spi.function.table.Argument;
+import io.trino.spi.function.table.Descriptor;
+import io.trino.spi.function.table.ScalarArgument;
+import io.trino.spi.function.table.ScalarArgumentSpecification;
+import io.trino.spi.function.table.TableFunctionAnalysis;
+import io.trino.spi.predicate.TupleDomain;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.function.table.ReturnTypeSpecification.GenericTable.GENERIC_TABLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+
+/** TableChangesFunction. */
+public class TableChangesFunction extends AbstractConnectorTableFunction {
+
+    private static final Slice INVALID_VALUE = Slices.utf8Slice("invalid");
+    private static final String FUNCTION_NAME = "table_changes";
+    private static final String SCHEMA_NAME_VAR_NAME = "SCHEMA_NAME";
+    private static final String TABLE_NAME_VAR_NAME = "TABLE_NAME";
+    private static final String INCREMENTAL_BETWEEN_SCAN_MODE =
+            TrinoTableOptionUtils.convertOptionKey(CoreOptions.INCREMENTAL_BETWEEN_SCAN_MODE.key())
+                    .toUpperCase(ENGLISH);
+    private static final String INCREMENTAL_BETWEEN_TIMESTAMP =
+            TrinoTableOptionUtils.convertOptionKey(CoreOptions.INCREMENTAL_BETWEEN_TIMESTAMP.key())
+                    .toUpperCase(ENGLISH);
+    private static final String INCREMENTAL_BETWEEN =
+            TrinoTableOptionUtils.convertOptionKey(CoreOptions.INCREMENTAL_BETWEEN.key())
+                    .toUpperCase(ENGLISH);
+    private final TrinoMetadata trinoMetadata;
+
+    @Inject
+    public TableChangesFunction(TrinoMetadataFactory trinoMetadataFactory) {
+        super(
+                "system",
+                FUNCTION_NAME,
+                ImmutableList.of(
+                        ScalarArgumentSpecification.builder()
+                                .name(SCHEMA_NAME_VAR_NAME)
+                                .type(VARCHAR)
+                                .build(),
+                        ScalarArgumentSpecification.builder()
+                                .name(TABLE_NAME_VAR_NAME)
+                                .type(VARCHAR)
+                                .build(),
+                        ScalarArgumentSpecification.builder()
+                                .name(INCREMENTAL_BETWEEN_SCAN_MODE)
+                                .defaultValue(
+                                        Slices.utf8Slice(
+                                                CoreOptions.INCREMENTAL_BETWEEN_SCAN_MODE
+                                                        .defaultValue()
+                                                        .getValue()))
+                                .type(VARCHAR)
+                                .build(),
+                        ScalarArgumentSpecification.builder()
+                                .name(INCREMENTAL_BETWEEN)
+                                .defaultValue(INVALID_VALUE)
+                                .type(VARCHAR)
+                                .build(),
+                        ScalarArgumentSpecification.builder()
+                                .name(INCREMENTAL_BETWEEN_TIMESTAMP)
+                                .defaultValue(INVALID_VALUE)
+                                .type(VARCHAR)
+                                .build()),
+                GENERIC_TABLE);
+        this.trinoMetadata =
+                requireNonNull(trinoMetadataFactory, "trinoMetadataFactory is null").create();
+    }
+
+    @Override
+    public TableFunctionAnalysis analyze(
+            ConnectorSession session,
+            ConnectorTransactionHandle transaction,
+            Map<String, Argument> arguments,
+            ConnectorAccessControl accessControl) {
+        String schema = getSchemaName(arguments);
+        String table = getTableName(arguments);
+
+        Slice incrementalBetweenValue =
+                (Slice) ((ScalarArgument) arguments.get(INCREMENTAL_BETWEEN)).getValue();
+        Slice incrementalBetweenTimestamp =
+                (Slice) ((ScalarArgument) arguments.get(INCREMENTAL_BETWEEN_TIMESTAMP)).getValue();
+        if (incrementalBetweenValue.equals(INVALID_VALUE)
+                && incrementalBetweenTimestamp.equals(INVALID_VALUE)) {
+            throw new TrinoException(
+                    INVALID_FUNCTION_ARGUMENT,
+                    "Either "
+                            + INCREMENTAL_BETWEEN
+                            + " or "
+                            + INCREMENTAL_BETWEEN_TIMESTAMP
+                            + " must be provided");
+        }
+
+        SchemaTableName schemaTableName = new SchemaTableName(schema, table);
+        try {
+            TrinoCatalog catalog = trinoMetadata.catalog();
+            catalog.initSession(session);
+            Table paimonTable = catalog.getTable(Identifier.create(schema, table));
+            Map<String, String> options = new HashMap<>(paimonTable.options());
+            if (!incrementalBetweenValue.equals(INVALID_VALUE)) {
+                options.put(
+                        CoreOptions.INCREMENTAL_BETWEEN.key(),
+                        incrementalBetweenValue.toStringUtf8());
+            }
+            if (!incrementalBetweenTimestamp.equals(INVALID_VALUE)) {
+                options.put(
+                        CoreOptions.INCREMENTAL_BETWEEN_TIMESTAMP.key(),
+                        incrementalBetweenTimestamp.toStringUtf8());
+            }
+
+            ImmutableList.Builder<Descriptor.Field> columns = ImmutableList.builder();
+            List<ColumnHandle> projectedColumns = new ArrayList<>();
+            paimonTable.rowType().getFields().stream()
+                    .forEach(
+                            column -> {
+                                columns.add(
+                                        new Descriptor.Field(
+                                                column.name(),
+                                                Optional.of(
+                                                        TrinoTypeUtils.fromPaimonType(
+                                                                column.type()))));
+                                projectedColumns.add(
+                                        TrinoColumnHandle.of(column.name(), column.type()));
+                            });
+            return TableFunctionAnalysis.builder()
+                    .returnedType(new Descriptor(columns.build()))
+                    .handle(
+                            new TrinoTableHandle(
+                                    schema,
+                                    table,
+                                    options,
+                                    TupleDomain.all(),
+                                    Optional.of(projectedColumns),
+                                    OptionalLong.empty()))
+                    .build();
+        } catch (Catalog.TableNotExistException e) {
+            throw new TrinoException(
+                    INVALID_FUNCTION_ARGUMENT, "Table not found: " + schemaTableName);
+        }
+    }
+
+    private static String getSchemaName(Map<String, Argument> arguments) {
+        if (argumentExists(arguments, SCHEMA_NAME_VAR_NAME)) {
+            return ((Slice)
+                            checkNonNull(
+                                    ((ScalarArgument) arguments.get(SCHEMA_NAME_VAR_NAME))
+                                            .getValue()))
+                    .toStringUtf8();
+        }
+        throw new TrinoException(
+                INVALID_FUNCTION_ARGUMENT, SCHEMA_NAME_VAR_NAME + " argument not found");
+    }
+
+    private static String getTableName(Map<String, Argument> arguments) {
+        if (argumentExists(arguments, TABLE_NAME_VAR_NAME)) {
+            return ((Slice)
+                            checkNonNull(
+                                    ((ScalarArgument) arguments.get(TABLE_NAME_VAR_NAME))
+                                            .getValue()))
+                    .toStringUtf8();
+        }
+        throw new TrinoException(
+                INVALID_FUNCTION_ARGUMENT, TABLE_NAME_VAR_NAME + " argument not found");
+    }
+
+    private static boolean argumentExists(Map<String, Argument> arguments, String key) {
+        Argument argument = arguments.get(key);
+        if (argument instanceof ScalarArgument scalarArgument) {
+            return !scalarArgument.getNullableValue().isNull();
+        }
+        throw new IllegalArgumentException("Unsupported argument type: " + argument);
+    }
+
+    private static Object checkNonNull(Object argumentValue) {
+        if (argumentValue == null) {
+            throw new TrinoException(
+                    INVALID_FUNCTION_ARGUMENT, FUNCTION_NAME + " arguments may not be null");
+        }
+        return argumentValue;
+    }
+}

--- a/src/main/java/org/apache/paimon/trino/functions/tablechanges/TableChangesFunctionProcessor.java
+++ b/src/main/java/org/apache/paimon/trino/functions/tablechanges/TableChangesFunctionProcessor.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.trino.functions.tablechanges;
+
+import org.apache.paimon.trino.TrinoPageSourceProvider;
+import org.apache.paimon.trino.TrinoSplit;
+import org.apache.paimon.trino.TrinoTableHandle;
+
+import io.trino.spi.Page;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.function.table.TableFunctionProcessorState;
+import io.trino.spi.function.table.TableFunctionSplitProcessor;
+
+import static io.trino.spi.function.table.TableFunctionProcessorState.Finished.FINISHED;
+
+/** TableChangesFunctionProcessor. */
+public class TableChangesFunctionProcessor implements TableFunctionSplitProcessor {
+
+    private static final Page EMPTY_PAGE = new Page(0);
+
+    private final ConnectorPageSource pageSource;
+
+    public TableChangesFunctionProcessor(
+            ConnectorSession session,
+            TrinoTableHandle handle,
+            TrinoSplit split,
+            TrinoPageSourceProvider pageSourceProvider) {
+        this.pageSource =
+                pageSourceProvider.createPageSource(
+                        null,
+                        session,
+                        split,
+                        (ConnectorTableHandle) handle,
+                        handle.getProjectedColumns().get(),
+                        DynamicFilter.EMPTY);
+    }
+
+    @Override
+    public TableFunctionProcessorState process() {
+        if (pageSource.isFinished()) {
+            return FINISHED;
+        }
+        Page dataPage = pageSource.getNextPage();
+        if (dataPage == null) {
+            return TableFunctionProcessorState.Processed.produced(EMPTY_PAGE);
+        } else {
+            return TableFunctionProcessorState.Processed.produced(dataPage);
+        }
+    }
+}

--- a/src/main/java/org/apache/paimon/trino/functions/tablechanges/TableChangesFunctionProcessorProvider.java
+++ b/src/main/java/org/apache/paimon/trino/functions/tablechanges/TableChangesFunctionProcessorProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.trino.functions.tablechanges;
+
+import org.apache.paimon.trino.TrinoPageSourceProvider;
+import org.apache.paimon.trino.TrinoSplit;
+import org.apache.paimon.trino.TrinoTableHandle;
+
+import com.google.inject.Inject;
+import io.trino.plugin.base.classloader.ClassLoaderSafeTableFunctionSplitProcessor;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.function.table.ConnectorTableFunctionHandle;
+import io.trino.spi.function.table.TableFunctionProcessorProvider;
+import io.trino.spi.function.table.TableFunctionSplitProcessor;
+
+/** TableChangesFunctionProcessorProvider. */
+public class TableChangesFunctionProcessorProvider implements TableFunctionProcessorProvider {
+
+    private final TrinoPageSourceProvider icebergPageSourceProvider;
+
+    @Inject
+    public TableChangesFunctionProcessorProvider(
+            TrinoPageSourceProvider icebergPageSourceProvider) {
+        this.icebergPageSourceProvider = icebergPageSourceProvider;
+    }
+
+    @Override
+    public TableFunctionSplitProcessor getSplitProcessor(
+            ConnectorSession session, ConnectorTableFunctionHandle handle, ConnectorSplit split) {
+        return new ClassLoaderSafeTableFunctionSplitProcessor(
+                new TableChangesFunctionProcessor(
+                        session,
+                        (TrinoTableHandle) handle,
+                        (TrinoSplit) split,
+                        icebergPageSourceProvider),
+                getClass().getClassLoader());
+    }
+}

--- a/src/main/java/org/apache/paimon/trino/functions/tablechanges/TableChangesFunctionProvider.java
+++ b/src/main/java/org/apache/paimon/trino/functions/tablechanges/TableChangesFunctionProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.trino.functions.tablechanges;
+
+import org.apache.paimon.trino.TrinoMetadataFactory;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorTableFunction;
+import io.trino.spi.function.table.ConnectorTableFunction;
+
+import static java.util.Objects.requireNonNull;
+
+/** TableChangesFunctionProvider. */
+public class TableChangesFunctionProvider implements Provider<ConnectorTableFunction> {
+    private final TrinoMetadataFactory trinoMetadataFactory;
+
+    @Inject
+    public TableChangesFunctionProvider(TrinoMetadataFactory trinoMetadataFactory) {
+        this.trinoMetadataFactory =
+                requireNonNull(trinoMetadataFactory, "trinoMetadataFactory is null");
+    }
+
+    @Override
+    public ConnectorTableFunction get() {
+        return new ClassLoaderSafeConnectorTableFunction(
+                new TableChangesFunction(trinoMetadataFactory), getClass().getClassLoader());
+    }
+}


### PR DESCRIPTION
1. Read incremental changes between start snapshot (exclusive) and end snapshot.
```
SELECT * FROM TABLE(paimon.system.table_changes(schema_name=>'schema_name',table_name=>'table_name',incremental_between=>'snap-1,snap-2'));

SELECT * FROM TABLE(paimon.system.table_changes(schema_name=>'schema_name',table_name=>'table_name',incremental_between=>'tag-1,tag-2'));

SELECT * FROM TABLE(paimon.system.table_changes(schema_name=>'schema_name',table_name=>'table_name',incremental_between_timestamp=>'t1,t2'));
```
2. Upgrade paimon-bundle dependency to 1.0.0
