### PR TITLE
fix: fixed bucket table insert error

### DIFF
--- a/src/main/java/org/apache/paimon/trino/FixedBucketTableShuffleFunction.java
+++ b/src/main/java/org/apache/paimon/trino/FixedBucketTableShuffleFunction.java
@@ -55,7 +55,7 @@ public class FixedBucketTableShuffleFunction implements BucketFunction {
                 ThreadLocal.withInitial(
                         () ->
                                 CodeGenUtils.newProjection(
-                                        schema.logicalPrimaryKeysType(), schema.primaryKeys()));
+                                        schema.logicalBucketKeyType(), schema.bucketKeys()));
         this.bucketCount = new CoreOptions(schema.options()).bucket();
         this.workerCount = workerCount;
         this.isRowId =


### PR DESCRIPTION
When a table is configured with a fixed number of buckets, an exception will occur when insert data： io.trino.spi.Page: blocks out of bounds