### PR TITLE
Bump Trino to 476 and Paimon to 1.3.1

### DIFF
--- a/.github/workflows/ci-jdk24.yml
+++ b/.github/workflows/ci-jdk24.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Java 21 Build
+name: Java 24 Build
 
 on: [push, pull_request]
 
@@ -24,10 +24,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Set up JDK 21
+      - name: Set up JDK 24
         uses: actions/setup-java@v1
         with:
-          java-version: 21
+          java-version: 24
       - name: Set up Toolchain
         shell: bash
         run: |
@@ -38,7 +38,7 @@ jobs:
           <toolchain>
            <type>jdk</type>
              <provides>
-               <version>21</version>
+               <version>24</version>
                <vendor>adopt</vendor>
              </provides>
              <configuration>

--- a/.github/workflows/publish_snapshot_jdk24.yml
+++ b/.github/workflows/publish_snapshot_jdk24.yml
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-name: Publish Snapshot JDK21
+name: Publish Snapshot JDK24
 
 on:
   schedule:
@@ -25,7 +25,7 @@ on:
   workflow_dispatch:
 
 env:
-  JDK_VERSION: 21
+  JDK_VERSION: 24
 
 concurrency:
   group: ps-${{ github.event.pull_request.number || github.ref }}
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      # temporarily publish the jdk21 version to maven
+      # temporarily publish the jdk24 version to maven
       - name: Set up JDK ${{ env.JDK_VERSION }}
         uses: actions/setup-java@v2
         with:
@@ -61,7 +61,7 @@ jobs:
           <toolchain>
            <type>jdk</type>
              <provides>
-               <version>21</version>
+               <version>24</version>
                <vendor>adopt</vendor>
              </provides>
              <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -224,6 +224,13 @@ under the License.
                 <version>${spotless.version}</version>
                 <configuration>
                     <java>
+                        <excludes>
+                            <exclude>src/main/java/org/apache/paimon/trino/TrinoColumnHandle.java</exclude>
+                            <exclude>src/main/java/org/apache/paimon/trino/TrinoMergeTableHandle.java</exclude>
+                            <exclude>src/main/java/org/apache/paimon/trino/TrinoPartitioningHandle.java</exclude>
+                            <exclude>src/main/java/org/apache/paimon/trino/TrinoSplit.java</exclude>
+                            <exclude>src/main/java/org/apache/paimon/trino/TrinoTableHandle.java</exclude>
+                        </excludes>
                         <googleJavaFormat>
                             <version>1.17.0</version>
                             <style>AOSP</style>
@@ -338,6 +345,12 @@ under the License.
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.13</version>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.paimon</groupId>
         <artifactId>paimon-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>paimon-trino-${trino.version}</artifactId>
@@ -37,11 +37,11 @@ under the License.
     </scm>
 
     <properties>
-        <paimon.version>1.0.0</paimon.version>
-        <target.java.version>21</target.java.version>
-        <jdk.test.version>21</jdk.test.version>
-        <trino.version>440</trino.version>
-        <airlift.version>241</airlift.version>
+        <paimon.version>1.3.1</paimon.version>
+        <target.java.version>24</target.java.version>
+        <jdk.test.version>24</jdk.test.version>
+        <trino.version>476</trino.version>
+        <airlift.version>336</airlift.version>
         <slice.version>2.2</slice.version>
         <maven.toolchains.plugin.version>3.1.0</maven.toolchains.plugin.version>
         <hadoop.apache.version>3.2.0-18</hadoop.apache.version>
@@ -69,6 +69,18 @@ under the License.
                 <exclusion>
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.airlift</groupId>
+                    <artifactId>bootstrap</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.airlift</groupId>
+                    <artifactId>configuration</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.airlift</groupId>
+                    <artifactId>log-manager</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -101,6 +113,7 @@ under the License.
             <groupId>io.trino</groupId>
             <artifactId>trino-hdfs</artifactId>
             <version>${trino.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -296,6 +309,33 @@ under the License.
                         <goals>
                             <goal>attached</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <id>unpack-trino-hdfs-zip</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>io.trino</groupId>
+                                    <artifactId>trino-hdfs</artifactId>
+                                    <version>${trino.version}</version>
+                                    <type>zip</type>
+                                    <outputDirectory>${project.build.directory}/trino-hdfs-zip</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.paimon</groupId>
         <artifactId>paimon-parent</artifactId>
-        <version>1.3.1-SNAPSHOT</version>
+        <version>1.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>paimon-trino-${trino.version}</artifactId>
@@ -44,7 +44,7 @@ under the License.
         <airlift.version>336</airlift.version>
         <slice.version>2.2</slice.version>
         <maven.toolchains.plugin.version>3.1.0</maven.toolchains.plugin.version>
-        <hadoop.apache.version>3.2.0-18</hadoop.apache.version>
+        <hadoop.apache.version>3.3.5-3</hadoop.apache.version>
         <junit5.version>5.8.1</junit5.version>
         <slf4j.version>2.0.13</slf4j.version>
         <guava.version>31.1-jre</guava.version>

--- a/src/main/assembly/paimon.xml
+++ b/src/main/assembly/paimon.xml
@@ -22,10 +22,29 @@
         <format>tar.gz</format>
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>
+    <files>
+        <file>
+            <source>${project.build.directory}/${project.build.finalName}.jar</source>
+            <outputDirectory>paimon</outputDirectory>
+        </file>
+    </files>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/trino-hdfs-zip/hdfs</directory>
+            <outputDirectory>paimon/hdfs</outputDirectory>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+        </fileSet>
+    </fileSets>
     <dependencySets>
         <dependencySet>
             <outputDirectory>paimon</outputDirectory>
             <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <excludes>
+                <exclude>io.trino:trino-hdfs</exclude>
+            </excludes>
         </dependencySet>
     </dependencySets>
 </assembly>

--- a/src/main/java/org/apache/paimon/trino/DirectTrinoPageSource.java
+++ b/src/main/java/org/apache/paimon/trino/DirectTrinoPageSource.java
@@ -20,6 +20,7 @@ package org.apache.paimon.trino;
 
 import io.trino.spi.Page;
 import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.SourcePage;
 import io.trino.spi.metrics.Metrics;
 
 import java.io.IOException;
@@ -32,6 +33,7 @@ public class DirectTrinoPageSource implements ConnectorPageSource {
     private ConnectorPageSource current;
     private final LinkedList<ConnectorPageSource> pageSourceQueue;
     private long completedBytes;
+    private long completedReadTimeNanos;
 
     public DirectTrinoPageSource(LinkedList<ConnectorPageSource> pageSourceQueue) {
         this.pageSourceQueue = pageSourceQueue;
@@ -45,7 +47,7 @@ public class DirectTrinoPageSource implements ConnectorPageSource {
 
     @Override
     public long getReadTimeNanos() {
-        return current == null ? 0 : current.getReadTimeNanos();
+        return completedReadTimeNanos + (current == null ? 0 : current.getReadTimeNanos());
     }
 
     @Override
@@ -59,7 +61,8 @@ public class DirectTrinoPageSource implements ConnectorPageSource {
             if (current == null) {
                 return null;
             }
-            Page dataPage = current.getNextPage();
+            SourcePage sourcePage = current.getNextSourcePage();
+            Page dataPage = sourcePage == null ? null : sourcePage.getPage();
             if (dataPage == null) {
                 advance();
                 return getNextPage();
@@ -77,6 +80,7 @@ public class DirectTrinoPageSource implements ConnectorPageSource {
         }
         try {
             completedBytes += current.getCompletedBytes();
+            completedReadTimeNanos += current.getReadTimeNanos();
             current.close();
         } catch (IOException e) {
             current = null;

--- a/src/main/java/org/apache/paimon/trino/FixedBucketTableShuffleFunction.java
+++ b/src/main/java/org/apache/paimon/trino/FixedBucketTableShuffleFunction.java
@@ -23,7 +23,6 @@ import org.apache.paimon.codegen.CodeGenUtils;
 import org.apache.paimon.codegen.Projection;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.schema.TableSchema;
-import org.apache.paimon.table.sink.KeyAndBucketExtractor;
 import org.apache.paimon.types.RowKind;
 
 import io.trino.spi.Page;
@@ -44,6 +43,7 @@ public class FixedBucketTableShuffleFunction implements BucketFunction {
     private final int bucketCount;
     private final boolean isRowId;
     private final ThreadLocal<Projection> projectionContext;
+    private final org.apache.paimon.bucket.BucketFunction paimonBucketFunction;
 
     public FixedBucketTableShuffleFunction(
             List<Type> partitionChannelTypes,
@@ -51,16 +51,31 @@ public class FixedBucketTableShuffleFunction implements BucketFunction {
             int workerCount) {
 
         TableSchema schema = partitioningHandle.getOriginalSchema();
-        this.projectionContext =
-                ThreadLocal.withInitial(
-                        () ->
-                                CodeGenUtils.newProjection(
-                                        schema.logicalPrimaryKeysType(), schema.primaryKeys()));
-        this.bucketCount = new CoreOptions(schema.options()).bucket();
-        this.workerCount = workerCount;
         this.isRowId =
                 partitionChannelTypes.size() == 1
                         && partitionChannelTypes.get(0) instanceof RowType;
+        if (isRowId) {
+            // UPDATE path: RowBlock is unwrapped to primary key fields;
+            // project bucket keys out of them
+            this.projectionContext =
+                    ThreadLocal.withInitial(
+                            () ->
+                                    CodeGenUtils.newProjection(
+                                            schema.logicalPrimaryKeysType(), schema.bucketKeys()));
+        } else {
+            // INSERT path: page contains only bucket key columns
+            this.projectionContext =
+                    ThreadLocal.withInitial(
+                            () ->
+                                    CodeGenUtils.newProjection(
+                                            schema.logicalBucketKeyType(), schema.bucketKeys()));
+        }
+        CoreOptions coreOptions = new CoreOptions(schema.options());
+        this.bucketCount = coreOptions.bucket();
+        this.paimonBucketFunction =
+                org.apache.paimon.bucket.BucketFunction.create(
+                        coreOptions, schema.logicalBucketKeyType());
+        this.workerCount = workerCount;
     }
 
     @Override
@@ -82,9 +97,7 @@ public class FixedBucketTableShuffleFunction implements BucketFunction {
 
         TrinoRow trinoRow = new TrinoRow(page.getSingleValuePage(position), RowKind.INSERT);
         BinaryRow pk = projectionContext.get().apply(trinoRow);
-        int bucket =
-                KeyAndBucketExtractor.bucket(
-                        KeyAndBucketExtractor.bucketKeyHashCode(pk), bucketCount);
+        int bucket = paimonBucketFunction.bucket(pk, bucketCount);
         return bucket % workerCount;
     }
 }

--- a/src/main/java/org/apache/paimon/trino/FixedBucketTableShuffleFunction.java
+++ b/src/main/java/org/apache/paimon/trino/FixedBucketTableShuffleFunction.java
@@ -97,6 +97,7 @@ public class FixedBucketTableShuffleFunction implements BucketFunction {
 
         TrinoRow trinoRow = new TrinoRow(page.getSingleValuePage(position), RowKind.INSERT);
         BinaryRow pk = projectionContext.get().apply(trinoRow);
+        // paimon 1.3.1 no longer support KeyAndBucketExtractor, should use BucketFunction
         int bucket = paimonBucketFunction.bucket(pk, bucketCount);
         return bucket % workerCount;
     }

--- a/src/main/java/org/apache/paimon/trino/TrinoConnectorFactory.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoConnectorFactory.java
@@ -29,8 +29,6 @@ import io.airlift.json.JsonModule;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import io.trino.filesystem.manager.FileSystemModule;
-import io.trino.hdfs.HdfsModule;
-import io.trino.hdfs.authentication.HdfsAuthenticationModule;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorPageSinkProvider;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorPageSourceProvider;
@@ -53,8 +51,6 @@ import org.w3c.dom.NodeList;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import java.io.File;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -101,11 +97,10 @@ public class TrinoConnectorFactory implements ConnectorFactory {
         ClassLoader classLoader = TrinoConnectorFactory.class.getClassLoader();
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             Bootstrap app =
+                    // HDFS should not be on the plugin classpath
                     new Bootstrap(
                             new JsonModule(),
                             new TrinoModule(config),
-                            new HdfsModule(),
-                            new HdfsAuthenticationModule(),
                             // bind the trino file system module
                             newFileSystemModule(catalogName, context),
                             binder -> {
@@ -194,18 +189,7 @@ public class TrinoConnectorFactory implements ConnectorFactory {
 
     private static FileSystemModule newFileSystemModule(
             String catalogName, ConnectorContext context) {
-        Constructor<?> constructor = FileSystemModule.class.getConstructors()[0];
-        try {
-            if (constructor.getParameterCount() == 0) {
-                return (FileSystemModule) constructor.newInstance();
-            } else {
-                // for trino 440
-                return (FileSystemModule)
-                        constructor.newInstance(
-                                catalogName, context.getNodeManager(), context.getOpenTelemetry());
-            }
-        } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
+        return new FileSystemModule(
+                catalogName, context.getNodeManager(), context.getOpenTelemetry(), false);
     }
 }

--- a/src/main/java/org/apache/paimon/trino/TrinoMetadata.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoMetadata.java
@@ -133,11 +133,10 @@ public class TrinoMetadata implements ConnectorMetadata {
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
-            case HASH_DYNAMIC:
             case BUCKET_UNAWARE:
                 return Optional.empty();
             default:
-                throw new IllegalArgumentException("Unknown table bucket mode: " + bucketMode);
+                throw new IllegalArgumentException("Unsupported table bucket mode: " + bucketMode);
         }
     }
 

--- a/src/main/java/org/apache/paimon/trino/TrinoMetadata.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoMetadata.java
@@ -60,6 +60,7 @@ import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.RowChangeParadigm;
+import io.trino.spi.connector.SaveMode;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.expression.ConnectorExpression;
@@ -110,7 +111,6 @@ public class TrinoMetadata implements ConnectorMetadata {
         return catalog;
     }
 
-    // todo support dynamic bucket table
     @Override
     public Optional<ConnectorTableLayout> getInsertLayout(
             ConnectorSession session, ConnectorTableHandle tableHandle) {
@@ -133,6 +133,7 @@ public class TrinoMetadata implements ConnectorMetadata {
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
+            case HASH_DYNAMIC:
             case BUCKET_UNAWARE:
                 return Optional.empty();
             default:
@@ -145,8 +146,12 @@ public class TrinoMetadata implements ConnectorMetadata {
             ConnectorSession session,
             ConnectorTableMetadata tableMetadata,
             Optional<ConnectorTableLayout> layout,
-            RetryMode retryMode) {
-        createTable(session, tableMetadata, false);
+            RetryMode retryMode,
+            boolean replace) {
+        if (replace) {
+            throw new UnsupportedOperationException("Create or replace table is not supported.");
+        }
+        createTable(session, tableMetadata, SaveMode.FAIL);
         return getTableHandle(session, tableMetadata.getTable(), Collections.emptyMap());
     }
 
@@ -175,6 +180,7 @@ public class TrinoMetadata implements ConnectorMetadata {
     public Optional<ConnectorOutputMetadata> finishInsert(
             ConnectorSession session,
             ConnectorInsertTableHandle insertHandle,
+            List<ConnectorTableHandle> sourceTableHandles,
             Collection<Slice> fragments,
             Collection<ComputedStatistics> computedStatistics) {
         return commit(session, (TrinoTableHandle) insertHandle, fragments);
@@ -263,7 +269,10 @@ public class TrinoMetadata implements ConnectorMetadata {
 
     @Override
     public ConnectorMergeTableHandle beginMerge(
-            ConnectorSession session, ConnectorTableHandle tableHandle, RetryMode retryMode) {
+            ConnectorSession session,
+            ConnectorTableHandle tableHandle,
+            Map<Integer, Collection<ColumnHandle>> updateCaseColumns,
+            RetryMode retryMode) {
         return new TrinoMergeTableHandle((TrinoTableHandle) tableHandle);
     }
 
@@ -271,6 +280,7 @@ public class TrinoMetadata implements ConnectorMetadata {
     public void finishMerge(
             ConnectorSession session,
             ConnectorMergeTableHandle mergeTableHandle,
+            List<ConnectorTableHandle> sourceTableHandles,
             Collection<Slice> fragments,
             Collection<ComputedStatistics> computedStatistics) {
         commit(session, (TrinoTableHandle) mergeTableHandle.getTableHandle(), fragments);
@@ -381,15 +391,14 @@ public class TrinoMetadata implements ConnectorMetadata {
                         } else {
                             try {
                                 catalog.initSession(session);
-                                String path =
+                                Table table =
                                         catalog.getTable(
-                                                        new Identifier(
-                                                                tableName.getSchemaName(),
-                                                                tableName.getTableName()))
-                                                .options()
-                                                .get("path");
+                                                new Identifier(
+                                                        tableName.getSchemaName(),
+                                                        tableName.getTableName()));
+                                String path = table.options().get("path");
 
-                                if (catalog.fileIO()
+                                if (table.fileIO()
                                         .exists(
                                                 new Path(
                                                         path
@@ -413,7 +422,6 @@ public class TrinoMetadata implements ConnectorMetadata {
         return getTableHandle(session, tableName, dynamicOptions);
     }
 
-    @Override
     public TrinoTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName) {
         return getTableHandle(session, tableName, Collections.emptyMap());
     }
@@ -492,9 +500,10 @@ public class TrinoMetadata implements ConnectorMetadata {
 
     @Override
     public void createTable(
-            ConnectorSession session,
-            ConnectorTableMetadata tableMetadata,
-            boolean ignoreExisting) {
+            ConnectorSession session, ConnectorTableMetadata tableMetadata, SaveMode saveMode) {
+        if (saveMode == SaveMode.REPLACE) {
+            throw new UnsupportedOperationException("Create or replace table is not supported.");
+        }
         SchemaTableName table = tableMetadata.getTable();
         Identifier identifier = Identifier.create(table.getSchemaName(), table.getTableName());
 
@@ -600,7 +609,10 @@ public class TrinoMetadata implements ConnectorMetadata {
 
     @Override
     public void addColumn(
-            ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column) {
+            ConnectorSession session,
+            ConnectorTableHandle tableHandle,
+            ColumnMetadata column,
+            io.trino.spi.connector.ColumnPosition position) {
         TrinoTableHandle trinoTableHandle = (TrinoTableHandle) tableHandle;
         Identifier identifier =
                 new Identifier(trinoTableHandle.getSchemaName(), trinoTableHandle.getTableName());
@@ -669,6 +681,7 @@ public class TrinoMetadata implements ConnectorMetadata {
                     new ConstraintApplicationResult<>(
                             trinoTableHandle.copy(trinoFilter.getFilter()),
                             trinoFilter.getRemainFilter(),
+                            constraint.getExpression(),
                             false));
         } else {
             return Optional.empty();

--- a/src/main/java/org/apache/paimon/trino/TrinoMetadataFactory.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoMetadataFactory.java
@@ -23,32 +23,46 @@ import org.apache.paimon.trino.catalog.TrinoCatalog;
 
 import com.google.inject.Inject;
 import io.trino.filesystem.TrinoFileSystemFactory;
-import io.trino.hdfs.ConfigurationUtils;
-import io.trino.hdfs.HdfsConfig;
-import io.trino.hdfs.HdfsConfigurationInitializer;
 import org.apache.hadoop.conf.Configuration;
+
+import java.util.Map;
 
 /** A factory to create {@link TrinoMetadata}. */
 public class TrinoMetadataFactory {
+    private static final String HADOOP_CONF_PREFIX = "hadoop.";
 
     private final TrinoCatalog catalog;
 
     @Inject
-    public TrinoMetadataFactory(
-            Options options,
-            HdfsConfigurationInitializer hdfsConfigurationInitializer,
-            HdfsConfig hdfsConfig,
-            TrinoFileSystemFactory fileSystemFactory) {
-        Configuration configuration = null;
-        if (!hdfsConfig.getResourceConfigFiles().isEmpty()) {
-            configuration = ConfigurationUtils.getInitialConfiguration();
-            hdfsConfigurationInitializer.initializeConfiguration(configuration);
-        }
-
-        this.catalog = new TrinoCatalog(options, configuration, fileSystemFactory);
+    public TrinoMetadataFactory(Options options, TrinoFileSystemFactory fileSystemFactory) {
+        this.catalog =
+                new TrinoCatalog(options, createHadoopConfiguration(options), fileSystemFactory);
     }
 
     public TrinoMetadata create() {
         return new TrinoMetadata(catalog);
+    }
+
+    // HDFS should not be on the plugin classpath
+    private static Configuration createHadoopConfiguration(Options options) {
+        Map<String, String> optionMap = options.toMap();
+        Configuration configuration = null;
+        for (Map.Entry<String, String> entry : optionMap.entrySet()) {
+            String key = entry.getKey();
+            if (!key.startsWith(HADOOP_CONF_PREFIX)) {
+                continue;
+            }
+
+            String value = entry.getValue();
+            if (value == null || value.isBlank()) {
+                continue;
+            }
+
+            if (configuration == null) {
+                configuration = new Configuration();
+            }
+            configuration.set(key.substring(HADOOP_CONF_PREFIX.length()), value);
+        }
+        return configuration;
     }
 }

--- a/src/main/java/org/apache/paimon/trino/TrinoPageSinkProvider.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoPageSinkProvider.java
@@ -97,11 +97,10 @@ public class TrinoPageSinkProvider implements ConnectorPageSinkProvider {
                         : BucketMode.HASH_FIXED;
         switch (mode) {
             case HASH_FIXED:
-            case HASH_DYNAMIC:
             case BUCKET_UNAWARE:
                 break;
             default:
-                throw new IllegalArgumentException("Unknown bucket mode: " + mode);
+                throw new IllegalArgumentException("Unsupported bucket mode: " + mode);
         }
     }
 

--- a/src/main/java/org/apache/paimon/trino/TrinoPageSinkProvider.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoPageSinkProvider.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.trino;
 
+import org.apache.paimon.disk.IOManagerImpl;
 import org.apache.paimon.table.BucketMode;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.Table;
@@ -83,6 +84,7 @@ public class TrinoPageSinkProvider implements ConnectorPageSinkProvider {
                         batchWriteBuilder.withOverwrite();
                     }
                     BatchTableWrite write = batchWriteBuilder.newWrite();
+                    write.withIOManager(new IOManagerImpl(System.getProperty("java.io.tmpdir")));
                     return new TrinoPageSink(write);
                 },
                 TrinoPageSinkProvider.class.getClassLoader());
@@ -95,6 +97,7 @@ public class TrinoPageSinkProvider implements ConnectorPageSinkProvider {
                         : BucketMode.HASH_FIXED;
         switch (mode) {
             case HASH_FIXED:
+            case HASH_DYNAMIC:
             case BUCKET_UNAWARE:
                 break;
             default:

--- a/src/main/java/org/apache/paimon/trino/TrinoPageSourceProvider.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoPageSourceProvider.java
@@ -48,7 +48,7 @@ import io.trino.orc.OrcReader;
 import io.trino.orc.OrcReaderOptions;
 import io.trino.orc.OrcRecordReader;
 import io.trino.orc.TupleDomainOrcPredicate;
-import io.trino.plugin.hive.FileFormatDataSourceStats;
+import io.trino.plugin.base.metrics.FileFormatDataSourceStats;
 import io.trino.plugin.hive.orc.OrcPageSource;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorPageSource;
@@ -211,24 +211,32 @@ public class TrinoPageSourceProvider implements ConnectorPageSourceProvider {
                                 }
                             }
                         }
+                        List<String> fileReadFields =
+                                fileStoreTable.schema().id() == rawFile.schemaId()
+                                        ? projectedFields
+                                        : schemaEvolutionFieldNames(
+                                                projectedFields,
+                                                rowType.getFields(),
+                                                schemaManager.schema(rawFile.schemaId()).fields());
+                        if (fileReadFields.contains(null)) {
+                            // Trino 476 no longer support ColumnAdaptation
+                            // Fallback to legacy way for schema evolution with missing fields.
+                            return createLegacyPageSource(
+                                    table,
+                                    paimonFilter,
+                                    fieldNames,
+                                    projectedFields,
+                                    paimonSplit,
+                                    columns,
+                                    limit);
+                        }
+
                         ConnectorPageSource source =
                                 createDataPageSource(
                                         rawFile.format(),
                                         fileSystem.newInputFile(Location.of(rawFile.path())),
                                         fileStoreTable.coreOptions(),
-                                        // map table column name to data column
-                                        // name, if column does not exist in
-                                        // data columns, set it to null
-                                        // columns those set to null will generate
-                                        // a null vector in orc page
-                                        fileStoreTable.schema().id() == rawFile.schemaId()
-                                                ? projectedFields
-                                                : schemaEvolutionFieldNames(
-                                                        projectedFields,
-                                                        rowType.getFields(),
-                                                        schemaManager
-                                                                .schema(rawFile.schemaId())
-                                                                .fields()),
+                                        fileReadFields,
                                         type,
                                         orderDomains(projectedFields, filter));
 
@@ -256,21 +264,40 @@ public class TrinoPageSourceProvider implements ConnectorPageSourceProvider {
                     throw new RuntimeException(e);
                 }
             } else {
-                int[] columnIndex =
-                        projectedFields.stream().mapToInt(fieldNames::indexOf).toArray();
-
-                // old read way
-                ReadBuilder read = table.newReadBuilder();
-                paimonFilter.ifPresent(read::withFilter);
-
-                if (!fieldNames.equals(projectedFields)) {
-                    read.withProjection(columnIndex);
-                }
-
-                return new TrinoPageSource(
-                        read.newRead().executeFilter().createReader(paimonSplit), columns, limit);
+                return createLegacyPageSource(
+                        table,
+                        paimonFilter,
+                        fieldNames,
+                        projectedFields,
+                        paimonSplit,
+                        columns,
+                        limit);
             }
         } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private ConnectorPageSource createLegacyPageSource(
+            Table table,
+            Optional<Predicate> paimonFilter,
+            List<String> fieldNames,
+            List<String> projectedFields,
+            Split paimonSplit,
+            List<ColumnHandle> columns,
+            OptionalLong limit) {
+        int[] columnIndex = projectedFields.stream().mapToInt(fieldNames::indexOf).toArray();
+        ReadBuilder read = table.newReadBuilder();
+        paimonFilter.ifPresent(read::withFilter);
+
+        if (!fieldNames.equals(projectedFields)) {
+            read.withProjection(columnIndex);
+        }
+
+        try {
+            return new TrinoPageSource(
+                    read.newRead().executeFilter().createReader(paimonSplit), columns, limit);
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
@@ -381,27 +408,23 @@ public class TrinoPageSourceProvider implements ConnectorPageSourceProvider {
             fileColumns.forEach(column -> fieldsMap.put(column.getColumnName(), column));
             TupleDomainOrcPredicate.TupleDomainOrcPredicateBuilder predicateBuilder =
                     TupleDomainOrcPredicate.builder();
-            List<OrcPageSource.ColumnAdaptation> columnAdaptations = new ArrayList<>();
             List<OrcColumn> fileReadColumns = new ArrayList<>(columns.size());
             List<Type> fileReadTypes = new ArrayList<>(columns.size());
 
             for (int i = 0; i < columns.size(); i++) {
-                if (columns.get(i) != null) {
-                    // column exists
-                    columnAdaptations.add(
-                            OrcPageSource.ColumnAdaptation.sourceColumn(fileReadColumns.size()));
-                    OrcColumn orcColumn = fieldsMap.get(columns.get(i));
-                    if (orcColumn == null) {
-                        throw new RuntimeException(
-                                "Column " + columns.get(i) + " does not exist in orc file.");
-                    }
-                    fileReadColumns.add(orcColumn);
-                    fileReadTypes.add(types.get(i));
-                    if (domains.get(i) != null) {
-                        predicateBuilder.addColumn(orcColumn.getColumnId(), domains.get(i));
-                    }
-                } else {
-                    columnAdaptations.add(OrcPageSource.ColumnAdaptation.nullColumn(types.get(i)));
+                if (columns.get(i) == null) {
+                    throw new RuntimeException(
+                            "Schema evolution with missing columns in ORC raw reader is unsupported.");
+                }
+                OrcColumn orcColumn = fieldsMap.get(columns.get(i));
+                if (orcColumn == null) {
+                    throw new RuntimeException(
+                            "Column " + columns.get(i) + " does not exist in orc file.");
+                }
+                fileReadColumns.add(orcColumn);
+                fileReadTypes.add(types.get(i));
+                if (domains.get(i) != null) {
+                    predicateBuilder.addColumn(orcColumn.getColumnId(), domains.get(i));
                 }
             }
 
@@ -410,6 +433,7 @@ public class TrinoPageSourceProvider implements ConnectorPageSourceProvider {
                     reader.createRecordReader(
                             fileReadColumns,
                             fileReadTypes,
+                            false,
                             predicateBuilder.build(),
                             DateTimeZone.UTC,
                             memoryUsage,
@@ -418,7 +442,6 @@ public class TrinoPageSourceProvider implements ConnectorPageSourceProvider {
 
             return new OrcPageSource(
                     recordReader,
-                    columnAdaptations,
                     orcDataSource,
                     Optional.empty(),
                     Optional.empty(),

--- a/src/main/java/org/apache/paimon/trino/TrinoPageSourceWrapper.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoPageSourceWrapper.java
@@ -23,6 +23,7 @@ import org.apache.paimon.deletionvectors.DeletionVector;
 
 import io.trino.spi.Page;
 import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.SourcePage;
 import io.trino.spi.metrics.Metrics;
 
 import java.io.IOException;
@@ -66,7 +67,8 @@ public class TrinoPageSourceWrapper implements ConnectorPageSource {
     @Override
     public Page getNextPage() {
         int startPosition = (int) source.getCompletedPositions().orElseThrow();
-        Page next = source.getNextPage();
+        SourcePage sourcePage = source.getNextSourcePage();
+        Page next = sourcePage == null ? null : sourcePage.getPage();
         if (next == null) {
             return next;
         }

--- a/src/main/java/org/apache/paimon/trino/TrinoRow.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoRow.java
@@ -24,10 +24,13 @@ import org.apache.paimon.data.InternalArray;
 import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
+import org.apache.paimon.data.variant.Variant;
 import org.apache.paimon.types.RowKind;
 
 import io.airlift.slice.Slice;
 import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.IntArrayBlock;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Int128;
 import io.trino.spi.type.TypeUtils;
@@ -44,6 +47,7 @@ import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static org.apache.paimon.shade.guava30.com.google.common.base.Verify.verify;
 
@@ -86,8 +90,7 @@ public class TrinoRow implements InternalRow, Serializable {
 
     @Override
     public byte getByte(int i) {
-        Slice slice = (Slice) TypeUtils.readNativeValue(VARBINARY, singlePage.getBlock(i), 0);
-        return slice.getByte(0);
+        return (byte) (long) TypeUtils.readNativeValue(TINYINT, singlePage.getBlock(i), 0);
     }
 
     @Override
@@ -101,7 +104,16 @@ public class TrinoRow implements InternalRow, Serializable {
 
     @Override
     public int getInt(int i) {
-        long value = (long) TypeUtils.readNativeValue(INTEGER, singlePage.getBlock(i), 0);
+        Block block = singlePage.getBlock(i);
+        long value;
+        if (block.getUnderlyingValueBlock() instanceof IntArrayBlock) {
+            // IntegerType and DateType are both backed by IntArrayBlock in the standard path.
+            value = (long) TypeUtils.readNativeValue(INTEGER, block, 0);
+        } else {
+            // In some Trino versions, date literals evaluated by the SQL engine may arrive
+            // as LongArrayBlock. Fall back to reading via BIGINT which uses LongArrayBlock.
+            value = BIGINT.getLong(block, 0);
+        }
         if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
             throw new IllegalArgumentException("Value out of range for int: " + value);
         }
@@ -175,6 +187,12 @@ public class TrinoRow implements InternalRow, Serializable {
 
     @Override
     public InternalRow getRow(int i, int i1) {
+        // todo
+        return null;
+    }
+
+    @Override
+    public Variant getVariant(int pos) {
         // todo
         return null;
     }

--- a/src/main/java/org/apache/paimon/trino/TrinoSplit.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoSplit.java
@@ -28,6 +28,7 @@ import io.trino.spi.connector.ConnectorSplit;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /** Trino {@link ConnectorSplit}. */
 public class TrinoSplit implements ConnectorSplit {
@@ -73,8 +74,8 @@ public class TrinoSplit implements ConnectorSplit {
     }
 
     @Override
-    public Object getInfo() {
-        return Collections.emptyMap();
+    public Map<String, String> getSplitInfo() {
+        return Map.of();
     }
 
     @Override

--- a/src/main/java/org/apache/paimon/trino/TrinoTypeUtils.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoTypeUtils.java
@@ -235,7 +235,7 @@ public class TrinoTypeUtils {
                                     VarcharType.MAX_LENGTH,
                                     ((VarcharType) trinoType).getBoundedLength()));
                 }
-                return DataTypes.VARCHAR(VarcharType.MAX_LENGTH);
+                return DataTypes.VARCHAR(VarCharType.MAX_LENGTH);
             } else if (trinoType instanceof io.trino.spi.type.BooleanType) {
                 return DataTypes.BOOLEAN();
             } else if (trinoType instanceof VarbinaryType) {

--- a/src/main/java/org/apache/paimon/trino/catalog/TrinoCatalog.java
+++ b/src/main/java/org/apache/paimon/trino/catalog/TrinoCatalog.java
@@ -18,19 +18,26 @@
 
 package org.apache.paimon.trino.catalog;
 
+import org.apache.paimon.PagedList;
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.catalog.CatalogLoader;
 import org.apache.paimon.catalog.Database;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.catalog.PropertyChange;
-import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.function.Function;
+import org.apache.paimon.function.FunctionChange;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
+import org.apache.paimon.partition.PartitionStatistics;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.security.SecurityContext;
+import org.apache.paimon.table.Instant;
 import org.apache.paimon.table.Table;
+import org.apache.paimon.table.TableSnapshot;
 import org.apache.paimon.trino.ClassLoaderUtils;
 import org.apache.paimon.trino.fileio.TrinoFileIOLoader;
 
@@ -39,8 +46,11 @@ import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.spi.connector.ConnectorSession;
 import org.apache.hadoop.conf.Configuration;
 
+import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /** Trino catalog, use it after set session. */
 public class TrinoCatalog implements Catalog {
@@ -94,32 +104,8 @@ public class TrinoCatalog implements Catalog {
     }
 
     @Override
-    public String warehouse() {
-        if (!inited) {
-            throw new RuntimeException("Not inited yet.");
-        }
-        return current.warehouse();
-    }
-
-    @Override
-    public Map<String, String> options() {
-        if (!inited) {
-            throw new RuntimeException("Not inited yet.");
-        }
-        return current.options();
-    }
-
-    @Override
     public boolean caseSensitive() {
         return current.caseSensitive();
-    }
-
-    @Override
-    public FileIO fileIO() {
-        if (!inited) {
-            throw new RuntimeException("Not inited yet.");
-        }
-        return current.fileIO();
     }
 
     @Override
@@ -128,6 +114,10 @@ public class TrinoCatalog implements Catalog {
     }
 
     @Override
+    public PagedList<String> listDatabasesPaged(@Nullable Integer maxResults, @Nullable String pageToken, @Nullable String databaseNamePattern) {
+        return current.listDatabasesPaged(maxResults, pageToken, databaseNamePattern);
+    }
+
     public void createDatabase(String s, boolean b, Map<String, String> map)
             throws DatabaseAlreadyExistException {
         current.createDatabase(s, b, map);
@@ -161,6 +151,15 @@ public class TrinoCatalog implements Catalog {
     }
 
     @Override
+    public PagedList<String> listTablesPaged(String databaseName, @Nullable Integer maxResults, @Nullable String pageToken, @Nullable String tableNamePattern, @Nullable String tableType) throws DatabaseNotExistException {
+        return current.listTablesPaged(databaseName, maxResults, pageToken, tableNamePattern, tableType);
+    }
+
+    @Override
+    public PagedList<Table> listTableDetailsPaged(String databaseName, @Nullable Integer maxResults, @Nullable String pageToken, @Nullable String tableNamePattern, @Nullable String tableType) throws DatabaseNotExistException {
+        return current.listTableDetailsPaged(databaseName, maxResults, pageToken, tableNamePattern, tableType);
+    }
+
     public void dropTable(Identifier identifier, boolean b) throws TableNotExistException {
         current.dropTable(identifier, b);
     }
@@ -184,23 +183,126 @@ public class TrinoCatalog implements Catalog {
     }
 
     @Override
-    public void createPartition(Identifier identifier, Map<String, String> map)
+    public List<Partition> listPartitions(Identifier identifier)
             throws TableNotExistException {
-        current.createPartition(identifier, map);
-    }
-
-    @Override
-    public void dropPartition(Identifier identifier, Map<String, String> partitions)
-            throws TableNotExistException, PartitionNotExistException {
-        current.dropPartition(identifier, partitions);
-    }
-
-    @Override
-    public List<Partition> listPartitions(Identifier identifier) throws TableNotExistException {
         return current.listPartitions(identifier);
     }
 
     @Override
+    public PagedList<Partition> listPartitionsPaged(Identifier identifier, @Nullable Integer maxResults, @Nullable String pageToken, @Nullable String partitionNamePattern) throws TableNotExistException {
+        return current.listPartitionsPaged(identifier, maxResults, pageToken, partitionNamePattern);
+    }
+
+    @Override
+    public boolean supportsListObjectsPaged() {
+        return current.supportsListObjectsPaged();
+    }
+
+    @Override
+    public boolean supportsVersionManagement() {
+        return current.supportsVersionManagement();
+    }
+
+    @Override
+    public boolean commitSnapshot(Identifier identifier, @Nullable String tableUuid, Snapshot snapshot, List<PartitionStatistics> statistics) throws TableNotExistException {
+        return current.commitSnapshot(identifier, tableUuid, snapshot, statistics);
+    }
+
+    @Override
+    public Optional<TableSnapshot> loadSnapshot(Identifier identifier) throws TableNotExistException {
+        return current.loadSnapshot(identifier);
+    }
+
+    @Override
+    public Optional<Snapshot> loadSnapshot(Identifier identifier, String version) throws TableNotExistException {
+        return current.loadSnapshot(identifier, version);
+    }
+
+    @Override
+    public PagedList<Snapshot> listSnapshotsPaged(Identifier identifier, @Nullable Integer maxResults, @Nullable String pageToken) throws TableNotExistException {
+        return current.listSnapshotsPaged(identifier, maxResults, pageToken);
+    }
+
+    @Override
+    public void rollbackTo(Identifier identifier, Instant instant) throws TableNotExistException {
+        current.rollbackTo(identifier, instant);
+    }
+
+    @Override
+    public void createBranch(Identifier identifier, String branch, @Nullable String fromTag) throws TableNotExistException, BranchAlreadyExistException, TagNotExistException {
+        current.createBranch(identifier, branch, fromTag);
+    }
+
+    @Override
+    public void dropBranch(Identifier identifier, String branch) throws BranchNotExistException {
+        current.dropBranch(identifier, branch);
+    }
+
+    @Override
+    public void fastForward(Identifier identifier, String branch) throws BranchNotExistException {
+        current.fastForward(identifier, branch);
+    }
+
+    @Override
+    public List<String> listBranches(Identifier identifier) throws TableNotExistException {
+        return current.listBranches(identifier);
+    }
+
+    @Override
+    public void createPartitions(Identifier identifier, List<Map<String, String>> partitions) throws TableNotExistException {
+        current.createPartitions(identifier, partitions);
+    }
+
+    @Override
+    public void dropPartitions(Identifier identifier, List<Map<String, String>> partitions) throws TableNotExistException {
+        current.dropPartitions(identifier, partitions);
+    }
+
+    @Override
+    public void alterPartitions(Identifier identifier, List<PartitionStatistics> partitions) throws TableNotExistException {
+        current.alterPartitions(identifier, partitions);
+    }
+
+    @Override
+    public List<String> listFunctions(String databaseName) throws DatabaseNotExistException {
+        return current.listFunctions(databaseName);
+    }
+
+    @Override
+    public Function getFunction(Identifier identifier) throws FunctionNotExistException {
+        return current.getFunction(identifier);
+    }
+
+    @Override
+    public void createFunction(Identifier identifier, Function function, boolean ignoreIfExists) throws FunctionAlreadyExistException, DatabaseNotExistException {
+        current.createFunction(identifier, function, ignoreIfExists);
+    }
+
+    @Override
+    public void dropFunction(Identifier identifier, boolean ignoreIfNotExists) throws FunctionNotExistException {
+        current.dropFunction(identifier, ignoreIfNotExists);
+    }
+
+    @Override
+    public void alterFunction(Identifier identifier, List<FunctionChange> changes, boolean ignoreIfNotExists) throws FunctionNotExistException, DefinitionAlreadyExistException, DefinitionNotExistException {
+        current.alterFunction(identifier, changes, ignoreIfNotExists);
+    }
+
+    @Override
+    public List<String> authTableQuery(Identifier identifier, @Nullable List<String> select) throws TableNotExistException {
+        return current.authTableQuery(identifier, select);
+    }
+
+    @Override
+    public Map<String, String> options() {
+        return current.options();
+    }
+
+    @Override
+    public CatalogLoader catalogLoader() {
+        return current.catalogLoader();
+    }
+
     public void close() throws Exception {
         if (current != null) {
             current.close();
@@ -215,7 +317,14 @@ public class TrinoCatalog implements Catalog {
 
     @Override
     public void alterTable(Identifier identifier, SchemaChange change, boolean ignoreIfNotExists)
-            throws TableNotExistException, ColumnAlreadyExistException, ColumnNotExistException {
+            throws TableNotExistException,
+                    ColumnAlreadyExistException,
+                    ColumnNotExistException {
         current.alterTable(identifier, change, ignoreIfNotExists);
+    }
+
+    @Override
+    public void markDonePartitions(Identifier identifier, List<Map<String, String>> partitions) throws TableNotExistException {
+        current.markDonePartitions(identifier, partitions);
     }
 }

--- a/src/main/java/org/apache/paimon/trino/catalog/TrinoCatalog.java
+++ b/src/main/java/org/apache/paimon/trino/catalog/TrinoCatalog.java
@@ -47,7 +47,7 @@ import io.trino.spi.connector.ConnectorSession;
 import org.apache.hadoop.conf.Configuration;
 
 import javax.annotation.Nullable;
-import java.util.Collections;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -114,7 +114,10 @@ public class TrinoCatalog implements Catalog {
     }
 
     @Override
-    public PagedList<String> listDatabasesPaged(@Nullable Integer maxResults, @Nullable String pageToken, @Nullable String databaseNamePattern) {
+    public PagedList<String> listDatabasesPaged(
+            @Nullable Integer maxResults,
+            @Nullable String pageToken,
+            @Nullable String databaseNamePattern) {
         return current.listDatabasesPaged(maxResults, pageToken, databaseNamePattern);
     }
 
@@ -151,13 +154,27 @@ public class TrinoCatalog implements Catalog {
     }
 
     @Override
-    public PagedList<String> listTablesPaged(String databaseName, @Nullable Integer maxResults, @Nullable String pageToken, @Nullable String tableNamePattern, @Nullable String tableType) throws DatabaseNotExistException {
-        return current.listTablesPaged(databaseName, maxResults, pageToken, tableNamePattern, tableType);
+    public PagedList<String> listTablesPaged(
+            String databaseName,
+            @Nullable Integer maxResults,
+            @Nullable String pageToken,
+            @Nullable String tableNamePattern,
+            @Nullable String tableType)
+            throws DatabaseNotExistException {
+        return current.listTablesPaged(
+                databaseName, maxResults, pageToken, tableNamePattern, tableType);
     }
 
     @Override
-    public PagedList<Table> listTableDetailsPaged(String databaseName, @Nullable Integer maxResults, @Nullable String pageToken, @Nullable String tableNamePattern, @Nullable String tableType) throws DatabaseNotExistException {
-        return current.listTableDetailsPaged(databaseName, maxResults, pageToken, tableNamePattern, tableType);
+    public PagedList<Table> listTableDetailsPaged(
+            String databaseName,
+            @Nullable Integer maxResults,
+            @Nullable String pageToken,
+            @Nullable String tableNamePattern,
+            @Nullable String tableType)
+            throws DatabaseNotExistException {
+        return current.listTableDetailsPaged(
+                databaseName, maxResults, pageToken, tableNamePattern, tableType);
     }
 
     public void dropTable(Identifier identifier, boolean b) throws TableNotExistException {
@@ -183,13 +200,17 @@ public class TrinoCatalog implements Catalog {
     }
 
     @Override
-    public List<Partition> listPartitions(Identifier identifier)
-            throws TableNotExistException {
+    public List<Partition> listPartitions(Identifier identifier) throws TableNotExistException {
         return current.listPartitions(identifier);
     }
 
     @Override
-    public PagedList<Partition> listPartitionsPaged(Identifier identifier, @Nullable Integer maxResults, @Nullable String pageToken, @Nullable String partitionNamePattern) throws TableNotExistException {
+    public PagedList<Partition> listPartitionsPaged(
+            Identifier identifier,
+            @Nullable Integer maxResults,
+            @Nullable String pageToken,
+            @Nullable String partitionNamePattern)
+            throws TableNotExistException {
         return current.listPartitionsPaged(identifier, maxResults, pageToken, partitionNamePattern);
     }
 
@@ -204,22 +225,31 @@ public class TrinoCatalog implements Catalog {
     }
 
     @Override
-    public boolean commitSnapshot(Identifier identifier, @Nullable String tableUuid, Snapshot snapshot, List<PartitionStatistics> statistics) throws TableNotExistException {
+    public boolean commitSnapshot(
+            Identifier identifier,
+            @Nullable String tableUuid,
+            Snapshot snapshot,
+            List<PartitionStatistics> statistics)
+            throws TableNotExistException {
         return current.commitSnapshot(identifier, tableUuid, snapshot, statistics);
     }
 
     @Override
-    public Optional<TableSnapshot> loadSnapshot(Identifier identifier) throws TableNotExistException {
+    public Optional<TableSnapshot> loadSnapshot(Identifier identifier)
+            throws TableNotExistException {
         return current.loadSnapshot(identifier);
     }
 
     @Override
-    public Optional<Snapshot> loadSnapshot(Identifier identifier, String version) throws TableNotExistException {
+    public Optional<Snapshot> loadSnapshot(Identifier identifier, String version)
+            throws TableNotExistException {
         return current.loadSnapshot(identifier, version);
     }
 
     @Override
-    public PagedList<Snapshot> listSnapshotsPaged(Identifier identifier, @Nullable Integer maxResults, @Nullable String pageToken) throws TableNotExistException {
+    public PagedList<Snapshot> listSnapshotsPaged(
+            Identifier identifier, @Nullable Integer maxResults, @Nullable String pageToken)
+            throws TableNotExistException {
         return current.listSnapshotsPaged(identifier, maxResults, pageToken);
     }
 
@@ -229,7 +259,8 @@ public class TrinoCatalog implements Catalog {
     }
 
     @Override
-    public void createBranch(Identifier identifier, String branch, @Nullable String fromTag) throws TableNotExistException, BranchAlreadyExistException, TagNotExistException {
+    public void createBranch(Identifier identifier, String branch, @Nullable String fromTag)
+            throws TableNotExistException, BranchAlreadyExistException, TagNotExistException {
         current.createBranch(identifier, branch, fromTag);
     }
 
@@ -249,17 +280,20 @@ public class TrinoCatalog implements Catalog {
     }
 
     @Override
-    public void createPartitions(Identifier identifier, List<Map<String, String>> partitions) throws TableNotExistException {
+    public void createPartitions(Identifier identifier, List<Map<String, String>> partitions)
+            throws TableNotExistException {
         current.createPartitions(identifier, partitions);
     }
 
     @Override
-    public void dropPartitions(Identifier identifier, List<Map<String, String>> partitions) throws TableNotExistException {
+    public void dropPartitions(Identifier identifier, List<Map<String, String>> partitions)
+            throws TableNotExistException {
         current.dropPartitions(identifier, partitions);
     }
 
     @Override
-    public void alterPartitions(Identifier identifier, List<PartitionStatistics> partitions) throws TableNotExistException {
+    public void alterPartitions(Identifier identifier, List<PartitionStatistics> partitions)
+            throws TableNotExistException {
         current.alterPartitions(identifier, partitions);
     }
 
@@ -274,22 +308,29 @@ public class TrinoCatalog implements Catalog {
     }
 
     @Override
-    public void createFunction(Identifier identifier, Function function, boolean ignoreIfExists) throws FunctionAlreadyExistException, DatabaseNotExistException {
+    public void createFunction(Identifier identifier, Function function, boolean ignoreIfExists)
+            throws FunctionAlreadyExistException, DatabaseNotExistException {
         current.createFunction(identifier, function, ignoreIfExists);
     }
 
     @Override
-    public void dropFunction(Identifier identifier, boolean ignoreIfNotExists) throws FunctionNotExistException {
+    public void dropFunction(Identifier identifier, boolean ignoreIfNotExists)
+            throws FunctionNotExistException {
         current.dropFunction(identifier, ignoreIfNotExists);
     }
 
     @Override
-    public void alterFunction(Identifier identifier, List<FunctionChange> changes, boolean ignoreIfNotExists) throws FunctionNotExistException, DefinitionAlreadyExistException, DefinitionNotExistException {
+    public void alterFunction(
+            Identifier identifier, List<FunctionChange> changes, boolean ignoreIfNotExists)
+            throws FunctionNotExistException,
+                    DefinitionAlreadyExistException,
+                    DefinitionNotExistException {
         current.alterFunction(identifier, changes, ignoreIfNotExists);
     }
 
     @Override
-    public List<String> authTableQuery(Identifier identifier, @Nullable List<String> select) throws TableNotExistException {
+    public List<String> authTableQuery(Identifier identifier, @Nullable List<String> select)
+            throws TableNotExistException {
         return current.authTableQuery(identifier, select);
     }
 
@@ -317,14 +358,13 @@ public class TrinoCatalog implements Catalog {
 
     @Override
     public void alterTable(Identifier identifier, SchemaChange change, boolean ignoreIfNotExists)
-            throws TableNotExistException,
-                    ColumnAlreadyExistException,
-                    ColumnNotExistException {
+            throws TableNotExistException, ColumnAlreadyExistException, ColumnNotExistException {
         current.alterTable(identifier, change, ignoreIfNotExists);
     }
 
     @Override
-    public void markDonePartitions(Identifier identifier, List<Map<String, String>> partitions) throws TableNotExistException {
+    public void markDonePartitions(Identifier identifier, List<Map<String, String>> partitions)
+            throws TableNotExistException {
         current.markDonePartitions(identifier, partitions);
     }
 }

--- a/src/main/java/org/apache/paimon/trino/fileio/BufferedSeekableInputStream.java
+++ b/src/main/java/org/apache/paimon/trino/fileio/BufferedSeekableInputStream.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.trino.fileio;
+
+import org.apache.paimon.fs.SeekableInputStream;
+
+import java.io.IOException;
+
+/**
+ * A buffered {@link SeekableInputStream} that reduces per-call I/O to the underlying stream.
+ *
+ * <p>Avro's {@code DataFileReader.sync()} scans for the sync marker one byte at a time via {@code
+ * BinaryDecoder.InputStreamByteSource.read()}. On object stores (OSS/S3/WASB), each unbuffered
+ * {@code read()} becomes an individual network request, causing extreme latency. For example, a
+ * 1768-byte manifest file can require ~886 individual network calls taking 6+ seconds.
+ *
+ * <p>This wrapper buffers reads in bulk (default 64 KB). A {@code seek()} within the currently
+ * buffered range only adjusts the buffer pointer without touching the underlying stream.
+ */
+public class BufferedSeekableInputStream extends SeekableInputStream {
+
+    private static final int DEFAULT_BUFFER_SIZE = 64 * 1024; // 64KB
+
+    private final SeekableInputStream in;
+    private final byte[] buffer;
+
+    /** File offset corresponding to {@code buffer[0]}. */
+    private long bufferStart;
+
+    /** Index within {@code buffer} of the current logical read position. */
+    private int bufferPos;
+
+    /** Number of valid bytes in {@code buffer} starting at index 0. */
+    private int bufferLen;
+
+    public BufferedSeekableInputStream(SeekableInputStream in) {
+        this(in, DEFAULT_BUFFER_SIZE);
+    }
+
+    public BufferedSeekableInputStream(SeekableInputStream in, int bufferSize) {
+        this.in = in;
+        this.buffer = new byte[bufferSize];
+        this.bufferStart = 0;
+        this.bufferPos = 0;
+        this.bufferLen = 0;
+    }
+
+    @Override
+    public long getPos() throws IOException {
+        return bufferStart + bufferPos;
+    }
+
+    @Override
+    public void seek(long pos) throws IOException {
+        if (pos >= bufferStart && pos < bufferStart + bufferLen) {
+            // Within buffered range: just move the pointer, no network I/O needed.
+            bufferPos = (int) (pos - bufferStart);
+        } else {
+            // Outside buffered range: invalidate buffer and seek underlying stream.
+            in.seek(pos);
+            bufferStart = pos;
+            bufferPos = 0;
+            bufferLen = 0;
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (bufferPos >= bufferLen) {
+            fillBuffer();
+            if (bufferLen == 0) {
+                return -1;
+            }
+        }
+        return buffer[bufferPos++] & 0xff;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        if (len == 0) {
+            return 0;
+        }
+        // First, drain any bytes already in the buffer.
+        if (bufferPos < bufferLen) {
+            int available = bufferLen - bufferPos;
+            int toCopy = Math.min(len, available);
+            System.arraycopy(buffer, bufferPos, b, off, toCopy);
+            bufferPos += toCopy;
+            return toCopy;
+        }
+        // Buffer is empty. For large requests (>= buffer capacity), bypass the buffer entirely to
+        // avoid the overhead of multiple fill-and-copy cycles through a 64KB intermediate buffer.
+        // This keeps bulk reads (ORC/Parquet stripe/row-group reads) at zero extra cost.
+        if (len >= buffer.length) {
+            bufferStart = bufferStart + bufferLen;
+            bufferLen = 0;
+            bufferPos = 0;
+            int n = in.read(b, off, len);
+            if (n > 0) {
+                bufferStart += n;
+            }
+            return n;
+        }
+        // Small request: fill the buffer and serve from it.
+        fillBuffer();
+        if (bufferLen == 0) {
+            return -1;
+        }
+        int toCopy = Math.min(len, bufferLen);
+        System.arraycopy(buffer, 0, b, off, toCopy);
+        bufferPos = toCopy;
+        return toCopy;
+    }
+
+    /**
+     * Refills the internal buffer from the underlying stream.
+     *
+     * <p>The underlying stream is always positioned at {@code bufferStart + bufferLen} after any
+     * operation (seeks within the buffer do not move the underlying stream pointer). Therefore we
+     * simply advance {@code bufferStart} and issue one bulk read.
+     */
+    private void fillBuffer() throws IOException {
+        bufferStart = bufferStart + bufferLen;
+        bufferPos = 0;
+        bufferLen = 0;
+        int n = in.read(buffer, 0, buffer.length);
+        if (n > 0) {
+            bufferLen = n;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        in.close();
+    }
+}

--- a/src/main/java/org/apache/paimon/trino/fileio/TrinoFileIO.java
+++ b/src/main/java/org/apache/paimon/trino/fileio/TrinoFileIO.java
@@ -60,8 +60,9 @@ public class TrinoFileIO implements FileIO {
 
     @Override
     public SeekableInputStream newInputStream(Path path) throws IOException {
-        return new TrinoInputStreamWrapper(
-                trinoFileSystem.newInputFile(Location.of(path.toString())).newStream());
+        return new BufferedSeekableInputStream(
+                new TrinoInputStreamWrapper(
+                        trinoFileSystem.newInputFile(Location.of(path.toString())).newStream()));
     }
 
     @Override

--- a/src/main/java/org/apache/paimon/trino/functions/tablechanges/TableChangesFunction.java
+++ b/src/main/java/org/apache/paimon/trino/functions/tablechanges/TableChangesFunction.java
@@ -99,7 +99,7 @@ public class TableChangesFunction extends AbstractConnectorTableFunction {
                                         Slices.utf8Slice(
                                                 CoreOptions.INCREMENTAL_BETWEEN_SCAN_MODE
                                                         .defaultValue()
-                                                        .getValue()))
+                                                        .toString()))
                                 .type(VARCHAR)
                                 .build(),
                         ScalarArgumentSpecification.builder()

--- a/src/test/java/org/apache/paimon/trino/TrinoDistributedQueryTest.java
+++ b/src/test/java/org/apache/paimon/trino/TrinoDistributedQueryTest.java
@@ -542,11 +542,6 @@ public class TrinoDistributedQueryTest extends AbstractDistributedEngineOnlyQuer
     }
 
     @Override
-    public void testLargePivot() {
-        throw new RuntimeException("TODO: test not implemented yet");
-    }
-
-    @Override
     public void testLimitAll() {
         throw new RuntimeException("TODO: test not implemented yet");
     }

--- a/src/test/java/org/apache/paimon/trino/TrinoDistributedQueryTest.java
+++ b/src/test/java/org/apache/paimon/trino/TrinoDistributedQueryTest.java
@@ -652,6 +652,11 @@ public class TrinoDistributedQueryTest extends AbstractDistributedEngineOnlyQuer
     }
 
     @Override
+    public void testMultipleConcurrentQueries() {
+        throw new RuntimeException("TODO: test not implemented yet");
+    }
+
+    @Override
     public void testMultipleOccurrencesOfCorrelatedSymbol() {
         throw new RuntimeException("TODO: test not implemented yet");
     }

--- a/src/test/java/org/apache/paimon/trino/TrinoITCase.java
+++ b/src/test/java/org/apache/paimon/trino/TrinoITCase.java
@@ -532,6 +532,29 @@ public class TrinoITCase extends AbstractTestQueryFramework {
         }
 
         {
+            Path tablePath = new Path(warehouse, "default.db/fixed_bucket_table_partitioned_wi_pk");
+            RowType rowType =
+                    new RowType(
+                            Arrays.asList(
+                                    new DataField(0, "order_key", DataTypes.BIGINT()),
+                                    new DataField(1, "order_name", DataTypes.STRING()),
+                                    new DataField(2, "order_date", DataTypes.DATE())));
+            new SchemaManager(LocalFileIO.create(), tablePath)
+                    .createTable(
+                            new Schema(
+                                    rowType.getFields(),
+                                    Arrays.asList("order_date"),
+                                    Arrays.asList("order_key", "order_date"),
+                                    new HashMap<>() {
+                                        {
+                                            put("bucket", "2");
+                                            put("bucket-key", "order_key");
+                                        }
+                                    },
+                                    ""));
+        }
+
+        {
             Path tablePath = new Path(warehouse, "default.db/unaware_table");
             RowType rowType =
                     new RowType(
@@ -561,6 +584,8 @@ public class TrinoITCase extends AbstractTestQueryFramework {
             queryRunner.installPlugin(new TrinoPlugin());
             Map<String, String> options = new HashMap<>();
             options.put("warehouse", warehouse);
+            options.put("fs.native-local.enabled", "true");
+            options.put("local.location", "/");
             queryRunner.createCatalog(CATALOG, CATALOG, options);
             return queryRunner;
         } catch (Throwable e) {
@@ -751,12 +776,13 @@ public class TrinoITCase extends AbstractTestQueryFramework {
         sql("ALTER TABLE paimon.default.t5 ADD COLUMN zip varchar");
         assertThat(sql("SHOW COLUMNS FROM paimon.default.t5"))
                 .isEqualTo(
-                        "[[order_key, bigint, , ], [order_status, varchar(2147483646), , ], [total_price, double, , ], [order_date, date, , ], [zip, varchar(2147483646), , ]]");
+                        "[[order_key, bigint, , ], [order_status, varchar, , ], [total_price, double, , ], [order_date, date, , ], [zip, varchar, , ]]");
         sql("DROP TABLE IF EXISTS paimon.default.t5");
     }
 
     @Test
     public void testRenameColumn() {
+        sql("DROP TABLE IF EXISTS paimon.default.t5");
         sql(
                 "CREATE TABLE t5 ("
                         + "  order_key bigint,"
@@ -775,7 +801,7 @@ public class TrinoITCase extends AbstractTestQueryFramework {
         sql("ALTER TABLE paimon.default.t5 RENAME COLUMN order_status to g");
         assertThat(sql("SHOW COLUMNS FROM paimon.default.t5"))
                 .isEqualTo(
-                        "[[order_key, bigint, , ], [g, varchar(2147483646), , ], [total_price, double, , ], [order_date, date, , ]]");
+                        "[[order_key, bigint, , ], [g, varchar, , ], [total_price, double, , ], [order_date, date, , ]]");
         sql("DROP TABLE IF EXISTS paimon.default.t5");
     }
 
@@ -932,6 +958,17 @@ public class TrinoITCase extends AbstractTestQueryFramework {
                 "INSERT INTO paimon.default.fixed_bucket_table_wo_pk VALUES (1,'1'),(2,'2'),(3,'3'),(4,'4'),(1,'1'),(2,'2'),(3,'3'),(4,'4')");
         assertThat(sql("SELECT * FROM paimon.default.fixed_bucket_table_wo_pk order by id asc"))
                 .isEqualTo("[[1, 1], [1, 1], [2, 2], [2, 2], [3, 3], [3, 3], [4, 4], [4, 4]]");
+    }
+
+    @Test
+    public void testInsertIntoFixedBucketPartitionedTableWithBucketKey() {
+        sql(
+                "INSERT INTO paimon.default.fixed_bucket_table_partitioned_wi_pk "
+                        + "VALUES (1, 'hello', DATE '2024-01-15'), (2, 'world', DATE '2024-01-15')");
+        assertThat(
+                        sql(
+                                "SELECT * FROM paimon.default.fixed_bucket_table_partitioned_wi_pk ORDER BY order_key ASC"))
+                .isEqualTo("[[1, hello, 2024-01-15], [2, world, 2024-01-15]]");
     }
 
     @Test

--- a/src/test/java/org/apache/paimon/trino/TrinoQueryRunner.java
+++ b/src/test/java/org/apache/paimon/trino/TrinoQueryRunner.java
@@ -67,6 +67,8 @@ public class TrinoQueryRunner {
         Map<String, String> options =
                 ImmutableMap.<String, String>builder()
                         .put("warehouse", catalogDir.toFile().toURI().toString())
+                        .put("fs.native-local.enabled", "true")
+                        .put("local.location", "/")
                         .putAll(extraConnectorProperties)
                         .build();
 

--- a/src/test/java/org/apache/paimon/trino/TrinoRowTest.java
+++ b/src/test/java/org/apache/paimon/trino/TrinoRowTest.java
@@ -41,6 +41,7 @@ import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -57,7 +58,7 @@ public class TrinoRowTest {
                         1,
                         writeNativeValue(BOOLEAN, null),
                         writeNativeValue(BOOLEAN, false),
-                        writeNativeValue(VARBINARY, Slices.wrappedBuffer((byte) 22)),
+                        writeNativeValue(TINYINT, 22L),
                         writeNativeValue(SMALLINT, 356L),
                         writeNativeValue(INTEGER, 4L),
                         writeNativeValue(BIGINT, 23567222L),

--- a/src/test/java/org/apache/paimon/trino/TrinoTypeTest.java
+++ b/src/test/java/org/apache/paimon/trino/TrinoTypeTest.java
@@ -146,7 +146,7 @@ public class TrinoTypeTest {
 
         DataType varCharType =
                 TrinoTypeUtils.toPaimonType(VarcharType.createUnboundedVarcharType());
-        assertThat(varCharType.asSQLString()).isEqualTo("VARCHAR(2147483646)");
+        assertThat(varCharType.asSQLString()).isEqualTo("STRING");
 
         DataType booleanType = TrinoTypeUtils.toPaimonType(BooleanType.BOOLEAN);
         assertThat(booleanType.asSQLString()).isEqualTo("BOOLEAN");
@@ -204,7 +204,7 @@ public class TrinoTypeTest {
                                 IntegerType.INTEGER,
                                 VarcharType.createUnboundedVarcharType(),
                                 new TypeOperators()));
-        assertThat(mapType.asSQLString()).isEqualTo("MAP<INT, VARCHAR(2147483646)>");
+        assertThat(mapType.asSQLString()).isEqualTo("MAP<INT, STRING>");
 
         List<RowType.Field> fields = new ArrayList<>();
         fields.add(new RowType.Field(java.util.Optional.of("id"), IntegerType.INTEGER));
@@ -213,6 +213,6 @@ public class TrinoTypeTest {
                         java.util.Optional.of("name"), VarcharType.createUnboundedVarcharType()));
         Type type = RowType.from(fields);
         DataType rowType = TrinoTypeUtils.toPaimonType(type);
-        assertThat(rowType.asSQLString()).isEqualTo("ROW<`id` INT, `name` VARCHAR(2147483646)>");
+        assertThat(rowType.asSQLString()).isEqualTo("ROW<`id` INT, `name` STRING>");
     }
 }


### PR DESCRIPTION
## Summary
Bump Trino version to 476 and Apache Paimon version to 1.3.1.

## Changes
- Adapt to Trino SPI breaking changes, including:
  - HDFS should not be on the plugin classpath
  - Trino no longer support ColumnAdaptation
- Adapt to Paimon breaking changes, including:
  - Paimon no longer support KeyAndBucketExtractor

## Testing
- [x] Existing unit tests pass
- [x] New test `testInsertIntoFixedBucketPartitionedTableWithBucketKey` added