### PR TITLE
Bump Trino to 480 and JDK to 25

### DIFF
--- a/.github/workflows/ci-jdk25.yml
+++ b/.github/workflows/ci-jdk25.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Java 24 Build
+name: Java 25 Build
 
 on: [push, pull_request]
 
@@ -24,10 +24,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Set up JDK 24
+      - name: Set up JDK 25
         uses: actions/setup-java@v1
         with:
-          java-version: 24
+          java-version: 25
       - name: Set up Toolchain
         shell: bash
         run: |
@@ -38,7 +38,7 @@ jobs:
           <toolchain>
            <type>jdk</type>
              <provides>
-               <version>24</version>
+               <version>25</version>
                <vendor>adopt</vendor>
              </provides>
              <configuration>

--- a/.github/workflows/publish_snapshot_jdk25.yml
+++ b/.github/workflows/publish_snapshot_jdk25.yml
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-name: Publish Snapshot JDK24
+name: Publish Snapshot JDK25
 
 on:
   schedule:
@@ -25,7 +25,7 @@ on:
   workflow_dispatch:
 
 env:
-  JDK_VERSION: 24
+  JDK_VERSION: 25
 
 concurrency:
   group: ps-${{ github.event.pull_request.number || github.ref }}
@@ -61,7 +61,7 @@ jobs:
           <toolchain>
            <type>jdk</type>
              <provides>
-               <version>24</version>
+               <version>25</version>
                <vendor>adopt</vendor>
              </provides>
              <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -38,11 +38,11 @@ under the License.
 
     <properties>
         <paimon.version>1.3.1</paimon.version>
-        <target.java.version>24</target.java.version>
-        <jdk.test.version>24</jdk.test.version>
-        <trino.version>476</trino.version>
-        <airlift.version>336</airlift.version>
-        <slice.version>2.2</slice.version>
+        <target.java.version>25</target.java.version>
+        <jdk.test.version>25</jdk.test.version>
+        <trino.version>480</trino.version>
+        <airlift.version>419</airlift.version>
+        <slice.version>2.7</slice.version>
         <maven.toolchains.plugin.version>3.1.0</maven.toolchains.plugin.version>
         <hadoop.apache.version>3.3.5-3</hadoop.apache.version>
         <junit5.version>5.8.1</junit5.version>
@@ -52,8 +52,9 @@ under the License.
         <findbugs.version>1.3.9</findbugs.version>
         <maven.checkstyle.version>3.1.2</maven.checkstyle.version>
         <maven.compiler.version>3.10.1</maven.compiler.version>
-        <spotless.version>2.43.0</spotless.version>
+        <spotless.version>2.46.1</spotless.version>
         <spotless.delimiter>package</spotless.delimiter>
+        <extraJavaTestArgs>--add-modules=jdk.incubator.vector --sun-misc-unsafe-memory-access=allow</extraJavaTestArgs>
     </properties>
 
     <dependencies>
@@ -230,9 +231,10 @@ under the License.
                             <exclude>src/main/java/org/apache/paimon/trino/TrinoPartitioningHandle.java</exclude>
                             <exclude>src/main/java/org/apache/paimon/trino/TrinoSplit.java</exclude>
                             <exclude>src/main/java/org/apache/paimon/trino/TrinoTableHandle.java</exclude>
+                            <exclude>src/test/java/org/apache/paimon/trino/TrinoColumnHandleTest.java</exclude>
                         </excludes>
                         <googleJavaFormat>
-                            <version>1.17.0</version>
+                            <version>1.28.0</version>
                             <style>AOSP</style>
                         </googleJavaFormat>
 
@@ -326,10 +328,10 @@ under the License.
                 <version>3.8.1</version>
                 <executions>
                     <execution>
-                        <id>unpack-trino-hdfs-zip</id>
+                        <id>copy-trino-hdfs-deps</id>
                         <phase>prepare-package</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>copy</goal>
                         </goals>
                         <configuration>
                             <artifactItems>
@@ -337,11 +339,10 @@ under the License.
                                     <groupId>io.trino</groupId>
                                     <artifactId>trino-hdfs</artifactId>
                                     <version>${trino.version}</version>
-                                    <type>zip</type>
-                                    <outputDirectory>${project.build.directory}/trino-hdfs-zip</outputDirectory>
+                                    <type>jar</type>
+                                    <outputDirectory>${project.build.directory}/trino-hdfs-zip/hdfs</outputDirectory>
                                 </artifactItem>
                             </artifactItems>
-                            <overWriteIfNewer>true</overWriteIfNewer>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/org/apache/paimon/trino/DirectTrinoPageSource.java
+++ b/src/main/java/org/apache/paimon/trino/DirectTrinoPageSource.java
@@ -18,7 +18,6 @@
 
 package org.apache.paimon.trino;
 
-import io.trino.spi.Page;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.SourcePage;
 import io.trino.spi.metrics.Metrics;
@@ -56,19 +55,18 @@ public class DirectTrinoPageSource implements ConnectorPageSource {
     }
 
     @Override
-    public Page getNextPage() {
+    public SourcePage getNextSourcePage() {
         try {
             if (current == null) {
                 return null;
             }
             SourcePage sourcePage = current.getNextSourcePage();
-            Page dataPage = sourcePage == null ? null : sourcePage.getPage();
-            if (dataPage == null) {
+            if (sourcePage == null) {
                 advance();
-                return getNextPage();
+                return getNextSourcePage();
             }
 
-            return dataPage;
+            return sourcePage;
         } catch (RuntimeException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/org/apache/paimon/trino/TrinoConnector.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoConnector.java
@@ -131,4 +131,7 @@ public class TrinoConnector implements Connector {
     public Optional<FunctionProvider> getFunctionProvider() {
         return Optional.of(functionProvider);
     }
+
+    @Override
+    public void shutdown() {}
 }

--- a/src/main/java/org/apache/paimon/trino/TrinoConnectorFactory.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoConnectorFactory.java
@@ -33,8 +33,8 @@ import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorPageSinkProvider;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorPageSourceProvider;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorSplitManager;
-import io.trino.plugin.hive.NodeVersion;
 import io.trino.plugin.hive.orc.OrcReaderConfig;
+import io.trino.spi.NodeVersion;
 import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
@@ -189,7 +189,6 @@ public class TrinoConnectorFactory implements ConnectorFactory {
 
     private static FileSystemModule newFileSystemModule(
             String catalogName, ConnectorContext context) {
-        return new FileSystemModule(
-                catalogName, context.getNodeManager(), context.getOpenTelemetry(), false);
+        return new FileSystemModule(catalogName, context, false);
     }
 }

--- a/src/main/java/org/apache/paimon/trino/TrinoMergePageSourceWrapper.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoMergePageSourceWrapper.java
@@ -22,6 +22,7 @@ import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.RowBlock;
 import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.SourcePage;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -60,11 +61,12 @@ public class TrinoMergePageSourceWrapper implements ConnectorPageSource {
     }
 
     @Override
-    public Page getNextPage() {
-        Page nextPage = pageSource.getNextPage();
-        if (nextPage == null) {
+    public SourcePage getNextSourcePage() {
+        SourcePage sourcePage = pageSource.getNextSourcePage();
+        if (sourcePage == null) {
             return null;
         }
+        Page nextPage = sourcePage.getPage();
         int rowCount = nextPage.getPositionCount();
 
         Block[] newBlocks = new Block[nextPage.getChannelCount() + 1];
@@ -81,7 +83,7 @@ public class TrinoMergePageSourceWrapper implements ConnectorPageSource {
                 RowBlock.fromNotNullSuppressedFieldBlocks(
                         rowCount, Optional.of(new boolean[fieldToIndex.size()]), rowIdBlocks);
 
-        return new Page(rowCount, newBlocks);
+        return SourcePage.create(new Page(rowCount, newBlocks));
     }
 
     @Override

--- a/src/main/java/org/apache/paimon/trino/TrinoMetadata.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoMetadata.java
@@ -527,7 +527,7 @@ public class TrinoMetadata implements ConnectorMetadata {
             builder.column(
                     column.getName(),
                     TrinoTypeUtils.toPaimonType(column.getType()),
-                    column.getComment());
+                    column.getComment().orElse(null));
         }
 
         TrinoTableOptionUtils.buildOptions(builder, properties);

--- a/src/main/java/org/apache/paimon/trino/TrinoPageSource.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoPageSource.java
@@ -43,6 +43,7 @@ import io.trino.spi.block.RowBlockBuilder;
 import io.trino.spi.block.RowValueBuilder;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.SourcePage;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Decimals;
@@ -133,16 +134,18 @@ public class TrinoPageSource implements ConnectorPageSource {
     }
 
     @Override
-    public Page getNextPage() {
-        return ClassLoaderUtils.runWithContextClassLoader(
-                () -> {
-                    try {
-                        return nextPage();
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                },
-                TrinoPageSource.class.getClassLoader());
+    public SourcePage getNextSourcePage() {
+        Page page =
+                ClassLoaderUtils.runWithContextClassLoader(
+                        () -> {
+                            try {
+                                return nextPage();
+                            } catch (IOException e) {
+                                throw new UncheckedIOException(e);
+                            }
+                        },
+                        TrinoPageSource.class.getClassLoader());
+        return page == null ? null : SourcePage.create(page);
     }
 
     @Override

--- a/src/main/java/org/apache/paimon/trino/TrinoPageSourceWrapper.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoPageSourceWrapper.java
@@ -65,21 +65,24 @@ public class TrinoPageSourceWrapper implements ConnectorPageSource {
     }
 
     @Override
-    public Page getNextPage() {
+    public SourcePage getNextSourcePage() {
         int startPosition = (int) source.getCompletedPositions().orElseThrow();
         SourcePage sourcePage = source.getNextSourcePage();
-        Page next = sourcePage == null ? null : sourcePage.getPage();
-        if (next == null) {
-            return next;
+        if (sourcePage == null) {
+            return null;
         }
 
+        Page next = sourcePage.getPage();
         int pageCount = next.getPositionCount();
 
-        return deletionVector
-                .map(
-                        deletionVector ->
-                                convertToRetained(next, deletionVector, startPosition, pageCount))
-                .orElse(next);
+        Page result =
+                deletionVector
+                        .map(
+                                deletionVector ->
+                                        convertToRetained(
+                                                next, deletionVector, startPosition, pageCount))
+                        .orElse(next);
+        return SourcePage.create(result);
     }
 
     @VisibleForTesting

--- a/src/main/java/org/apache/paimon/trino/TrinoSplit.java
+++ b/src/main/java/org/apache/paimon/trino/TrinoSplit.java
@@ -28,7 +28,6 @@ import io.trino.spi.connector.ConnectorSplit;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 /** Trino {@link ConnectorSplit}. */
 public class TrinoSplit implements ConnectorSplit {
@@ -71,11 +70,6 @@ public class TrinoSplit implements ConnectorSplit {
     @Override
     public List<HostAddress> getAddresses() {
         return Collections.emptyList();
-    }
-
-    @Override
-    public Map<String, String> getSplitInfo() {
-        return Map.of();
     }
 
     @Override

--- a/src/main/java/org/apache/paimon/trino/functions/tablechanges/TableChangesFunctionProcessor.java
+++ b/src/main/java/org/apache/paimon/trino/functions/tablechanges/TableChangesFunctionProcessor.java
@@ -27,6 +27,7 @@ import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.connector.SourcePage;
 import io.trino.spi.function.table.TableFunctionProcessorState;
 import io.trino.spi.function.table.TableFunctionSplitProcessor;
 
@@ -59,11 +60,11 @@ public class TableChangesFunctionProcessor implements TableFunctionSplitProcesso
         if (pageSource.isFinished()) {
             return FINISHED;
         }
-        Page dataPage = pageSource.getNextPage();
-        if (dataPage == null) {
+        SourcePage sourcePage = pageSource.getNextSourcePage();
+        if (sourcePage == null) {
             return TableFunctionProcessorState.Processed.produced(EMPTY_PAGE);
         } else {
-            return TableFunctionProcessorState.Processed.produced(dataPage);
+            return TableFunctionProcessorState.Processed.produced(sourcePage.getPage());
         }
     }
 }

--- a/src/test/java/org/apache/paimon/trino/TrinoColumnHandleTest.java
+++ b/src/test/java/org/apache/paimon/trino/TrinoColumnHandleTest.java
@@ -21,9 +21,10 @@ package org.apache.paimon.trino;
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.paimon.types.DataTypes;
 
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
-import io.airlift.json.ObjectMapperProvider;
+import io.airlift.json.JsonMapperProvider;
 import io.trino.spi.type.Type;
 import io.trino.type.TypeDeserializer;
 import org.junit.jupiter.api.Test;
@@ -41,11 +42,14 @@ public class TrinoColumnHandleTest {
     }
 
     private void testRoundTrip(TrinoColumnHandle expected) {
-        ObjectMapperProvider objectMapperProvider = new ObjectMapperProvider();
-        objectMapperProvider.setJsonDeserializers(
-                ImmutableMap.of(Type.class, new TypeDeserializer(TESTING_TYPE_MANAGER)));
+        JsonMapper jsonMapper =
+                new JsonMapperProvider()
+                        .withJsonDeserializers(
+                                ImmutableMap.of(
+                                        Type.class, new TypeDeserializer(TESTING_TYPE_MANAGER)))
+                        .get();
         JsonCodec<TrinoColumnHandle> codec =
-                new JsonCodecFactory(objectMapperProvider).jsonCodec(TrinoColumnHandle.class);
+                new JsonCodecFactory(jsonMapper).jsonCodec(TrinoColumnHandle.class);
 
         String json = codec.toJson(expected);
         TrinoColumnHandle actual = codec.fromJson(json);

--- a/src/test/java/org/apache/paimon/trino/TrinoDistributedQueryTest.java
+++ b/src/test/java/org/apache/paimon/trino/TrinoDistributedQueryTest.java
@@ -302,6 +302,11 @@ public class TrinoDistributedQueryTest extends AbstractDistributedEngineOnlyQuer
     }
 
     @Override
+    public void testDefaultExplainJsonFormat() {
+        throw new RuntimeException("TODO: test not implemented yet");
+    }
+
+    @Override
     public void testDefaultExplainTextFormat() {
         throw new RuntimeException("TODO: test not implemented yet");
     }
@@ -558,6 +563,11 @@ public class TrinoDistributedQueryTest extends AbstractDistributedEngineOnlyQuer
 
     @Override
     public void testLogicalExplain() {
+        throw new RuntimeException("TODO: test not implemented yet");
+    }
+
+    @Override
+    public void testLogicalExplainJsonFormat() {
         throw new RuntimeException("TODO: test not implemented yet");
     }
 

--- a/src/test/java/org/apache/paimon/trino/TrinoTypeTest.java
+++ b/src/test/java/org/apache/paimon/trino/TrinoTypeTest.java
@@ -136,7 +136,7 @@ public class TrinoTypeTest {
                                 new DataField(0, "id", new IntType()),
                                 new DataField(1, "name", new VarCharType(Integer.MAX_VALUE))));
         assertThat(Objects.requireNonNull(row).getDisplayName())
-                .isEqualTo("row(id integer, name varchar)");
+                .isEqualTo("row(\"id\" integer, \"name\" varchar)");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Upgrade Trino from 476 to 480 and JDK from 24 to 25
- Bump dependency versions: airlift 336 → 419, slice 2.2 → 2.7, spotless 2.43.0 → 2.46.1, google-java-format 1.17.0 → 1.28.0
- Adapt to Trino 480 SPI breaking changes
- Replace `trino-hdfs:zip` unpack with `trino-hdfs:jar` copy (zip artifact no longer published to Maven Central)
- Update CI workflows from JDK 24 to JDK 25

## Breaking SPI changes addressed

| Trino SPI Change | Affected File(s) | Adaptation |
|---|---|---|
| `ConnectorPageSource.getNextPage()` removed; must use `getNextSourcePage()` returning `SourcePage` | `TrinoPageSource`, `TrinoPageSourceWrapper`, `TrinoMergePageSourceWrapper`, `DirectTrinoPageSource`, `TableChangesFunctionProcessor` | Migrate all implementations and callers from `getNextPage()` to `getNextSourcePage()` |
| `Connector.shutdown()` changed from default to abstract | `TrinoConnector` | Add explicit empty `shutdown()` override |
| `ColumnMetadata.getComment()` returns `Optional<String>` instead of nullable `String` | `TrinoMetadata` | Use `.orElse(null)` to preserve existing semantics |
| `ConnectorSplit.getSplitInfo()` removed | `TrinoSplit` | Remove override and unused `Map` import |
| `NodeVersion` moved from `io.trino.plugin.hive` to `io.trino.spi` | `TrinoConnectorFactory` | Update import |
| `FileSystemModule` constructor changed from `(String, NodeManager, OpenTelemetry, boolean)` to `(String, ConnectorContext, boolean)` | `TrinoConnectorFactory` | Pass `ConnectorContext` directly |
| Airlift `JsonCodecFactory` no longer accepts `ObjectMapperProvider`; requires `JsonMapper` | `TrinoColumnHandleTest` | Migrate to `JsonMapperProvider` API |
| Row type display now quotes field names | `TrinoTypeTest` | Update assertion to expect `row("id" integer, "name" varchar)` |
| New inherited test methods `testDefaultExplainJsonFormat` / `testLogicalExplainJsonFormat` | `TrinoDistributedQueryTest` | Add overrides following existing pattern |

## Dependency version changes

| Dependency | Old | New |
|---|---|---|
| Trino | 476 | 480 |
| JDK | 24 | 25 |
| Airlift | 336 | 419 |
| Slice | 2.2 | 2.7 |
| Spotless Maven Plugin | 2.43.0 | 2.46.1 |
| google-java-format | 1.17.0 | 1.28.0 |

## Other changes

- **trino-hdfs packaging**: Replaced `maven-dependency-plugin:unpack` of `trino-hdfs:zip` with `copy` of `trino-hdfs:jar`. Trino 480 no longer publishes the zip artifact to Maven Central. The transitive HDFS dependencies are already covered by other runtime dependencies in the main plugin directory.
- **JVM test args**: Added `extraJavaTestArgs` with `--add-modules=jdk.incubator.vector --sun-misc-unsafe-memory-access=allow`, required by Trino 480 test framework on JDK 25.
- **Spotless**: Upgraded to 2.46.1 with google-java-format 1.28.0 for JDK 25 compatibility. Added `TrinoColumnHandleTest.java` to spotless excludes because spotless incorrectly rewrites `com.fasterxml.jackson` import to paimon-shaded variant.
- **CI**: Renamed workflow files from `*jdk24*` to `*jdk25*` and updated all JDK version references.

## Test plan

- [x] `mvn test` — 148 tests pass (unit + distributed query tests)
- [x] `mvn test -Dtest=TrinoITCase` — 30 integration tests pass
- [x] `mvn package -DskipTests` — plugin assembly builds successfully
- [x] Full build with spotless + checkstyle — no violations